### PR TITLE
P0: Add registry-style consumer smoke test path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,11 @@ jobs:
   verify-publish:
     name: Verify Published Artifacts
     needs: [publish-npm, publish-crate]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    if: >-
+      always() && !cancelled() && (
+        github.event_name == 'workflow_dispatch' ||
+        (needs.publish-npm.result == 'success' && needs.publish-crate.result == 'success')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Adds a `consumer-smoke` job to the publish workflow that scaffolds a project from the published `create-gametau`, installs dependencies, and builds for web — validating the full end-user install-to-build flow
- Adds `workflow_dispatch` trigger with a `version` input so verification + smoke can be run on-demand against already-published versions without re-publishing
- CI/publish jobs are conditionally skipped during manual dispatch; verify-publish handles both trigger paths

## Workflow graph

**Tag push (full flow):**
```
ci → publish-npm  ─┐
                    ├→ verify-publish → consumer-smoke
ci → publish-crate ─┘
```

**Manual dispatch (verification only):**
```
verify-publish → consumer-smoke
```

## Test plan
- [ ] Workflow YAML parses correctly (no syntax errors in CI)
- [ ] Consumer smoke job appears in the workflow graph
- [ ] On next tag push, smoke test scaffolds + builds successfully
- [ ] Manual `workflow_dispatch` with `version: 0.1.0` runs verify + smoke without publishing

Stacked on #16. Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)