### PR TITLE
chore(release): prepare v0.3.0-alpha.2 parity docs and manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0-alpha.2] - 2026-02-27
+
+### Added
+- Runtime parity shims for `@tauri-apps/api/app` and `@tauri-apps/api/path` (`webtau/app`, `webtau/path`)
+- `webtau-vite` alias coverage for `@tauri-apps/api/app` and `@tauri-apps/api/path`
+- Public function-level parity documentation in `docs/PARITY-MATRIX.md`
+
+### Fixed
+- Prerelease version alignment so tag-triggered publish uses unreleased `0.3.0-alpha.2` manifests instead of previously published `0.2.1` versions
+- `webtau/app` setter signatures now accept `null` reset values without type-unsafe casts in tests
+
+### Changed
+- Workspace, crate, and npm package versions bumped to `0.3.0-alpha.2`
+- `create-gametau` template dependencies now target `webtau`/`webtau-vite` `^0.3.0-alpha.2` and Rust `webtau = "0.3.0-alpha.2"`
+
 ## [0.2.1] - 2026-02-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0-alpha.2"
 edition = "2021"
 rust-version = "1.77"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ pub fn tick_world(state: &mut GameWorld) -> TickResult {
 
 When `webtau-vite` aliases `@tauri-apps/api/*` imports to `webtau/*`, these shims provide browser-compatible implementations:
 
+For a complete function-level status (implemented, partial, no-op, missing), see the [Parity Matrix](docs/PARITY-MATRIX.md).
+
 **`webtau/window`** — Web shim for `@tauri-apps/api/window`. Import `getCurrentWindow()` — same API as Tauri.
 
 | Method | Web Implementation |
@@ -307,6 +309,25 @@ When `webtau-vite` aliases `@tauri-apps/api/*` imports to `webtau/*`, these shim
 | `once(event, cb)` | Auto-unlisten after first callback |
 | `emit(event, payload)` | `window.dispatchEvent(new CustomEvent(...))` |
 | `emitTo(target, event, payload)` | Web-mode alias of `emit` |
+
+**`webtau/app`** — Web shim for `@tauri-apps/api/app`.
+
+| Method | Web Implementation |
+|---|---|
+| `getName()` | Configured app name, then `document.title`, then `"gametau-app"` |
+| `getVersion()` | Configured app version, then `"0.0.0"` |
+| `getTauriVersion()` | `"web"` sentinel in browser mode |
+| `show()` / `hide()` | No-op in browser tabs |
+| `setAppName(name \| null)` / `setAppVersion(version \| null)` | webtau-specific fallback configurators |
+
+**`webtau/path`** — Web shim for `@tauri-apps/api/path`.
+
+| Method Group | Web Implementation |
+|---|---|
+| Virtual dirs (`appDataDir`, `appConfigDir`, `homeDir`, etc.) | Deterministic virtual `/app/*` paths for browser usage |
+| `basename`, `dirname`, `extname`, `join`, `normalize`, `resolve`, `isAbsolute`, `sep` | POSIX-style path utilities for web mode |
+
+Not all Tauri `path` APIs are implemented yet (for example `resolveResource` and `delimiter`). See [Parity Matrix](docs/PARITY-MATRIX.md) for exact coverage.
 
 ### Gameplay foundation modules
 
@@ -621,7 +642,8 @@ Manual v1 wrappers remain fully supported — you can migrate command-by-command
 ## Roadmap
 
 - **`0.2.x` (shipped, current stable line)**: docs/adoption + parity/foundation backlog is delivered (tutorial, API docs pipeline, release incident checklist, `fs/dialog/event` shims, and `input/audio/assets` modules). See [CHANGELOG `0.2.1`](./CHANGELOG.md#021---2026-02-26) and [roadmap issue #6](https://github.com/devallibus/gametau/issues/6).
-- **`0.3.0` (planned)**: deepen runtime surface and production ergonomics (module maturation, parity expansion, and adoption hardening).
+- **`0.3.0-alpha.2` (current prerelease line)**: `app/path` runtime parity shims are shipped and documented; production ergonomics and public parity narrative continue under [roadmap issue #28](https://github.com/devallibus/gametau/issues/28).
+- **`0.3.0` (planned stable milestone)**: deepen runtime surface and production ergonomics (module maturation, parity expansion, and adoption hardening).
 - **`0.4.0+` (future)**: broader platform capabilities and ecosystem expansion.
 
 ## Support & Commercial Licensing

--- a/crates/webtau/Cargo.toml
+++ b/crates/webtau/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-webtau-macros = { path = "../webtau-macros", version = "=0.2.1" }
+webtau-macros = { path = "../webtau-macros", version = "=0.3.0-alpha.2" }

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -91,7 +91,14 @@ Desktop build:
 bun run build:desktop
 ```
 
-## 8) Next Steps
+## 8) Understand What's Available
+
+Before expanding your game, check current runtime parity and API surface:
+
+- Function-level parity matrix: `docs/PARITY-MATRIX.md`
+- Live API docs: `https://devallibus.github.io/gametau/api/`
+
+## 9) Next Steps
 
 - Read architecture details in `README.md`
 - Review release/incident procedures in `docs/RELEASE-INCIDENT-RESPONSE.md`

--- a/docs/PARITY-MATRIX.md
+++ b/docs/PARITY-MATRIX.md
@@ -1,0 +1,208 @@
+# webtau Parity Matrix
+
+This document tracks how `webtau` web shims compare to the `@tauri-apps/api/*` namespaces that `webtau-vite` aliases in web builds.
+
+Scope:
+- Aliased shim modules: `core`, `window`, `dpi`, `fs`, `dialog`, `event`, `app`, `path`
+- Foundation modules (no Tauri equivalent): `input`, `audio`, `assets`
+
+## Legend
+
+- `Implemented`: same API name is available and usable in web mode.
+- `No-op`: API exists for compatibility but intentionally does nothing on web.
+- `Partial`: API name exists, but semantics differ from native Tauri behavior.
+- `Not implemented`: available in Tauri but not provided by current `webtau` shim.
+
+## Coverage Summary (v0.3.0-alpha.2)
+
+Coverage is an approximate function-level view of each aliased namespace.
+
+| Module | Coverage | Notes |
+|---|---:|---|
+| `webtau/core` | ~20% | Focused on `invoke()` parity; `configure()`/`isTauri()` are webtau-specific helpers |
+| `webtau/window` | ~40% | Common gameplay/window controls implemented; many advanced window APIs are not implemented |
+| `webtau/dpi` | 100% | Core logical/physical size and position classes are implemented |
+| `webtau/fs` | ~50% | Core read/write/dir primitives implemented via IndexedDB-backed virtual FS |
+| `webtau/dialog` | 100% (name-level), partial semantics | All common dialog functions exist; browser behavior differs from desktop |
+| `webtau/event` | 100% (name-level), partial semantics | Event API exists; web behavior is browser/local-event scoped |
+| `webtau/app` | ~38% | 5/13 Tauri app APIs implemented (`getName/getVersion/getTauriVersion/show/hide`) |
+| `webtau/path` | ~70% | 23/33 Tauri path APIs implemented; missing advanced/system resolvers and helpers |
+
+---
+
+## `webtau/core` vs `@tauri-apps/api/core`
+
+| Export | Status | Web behavior | Tauri equivalent |
+|---|---|---|---|
+| `invoke(command, args?)` | Implemented (partial) | Calls WASM export in web mode; delegates to Tauri IPC in Tauri mode | `invoke` |
+| `configure({ loadWasm, onLoadError? })` | webtau-specific | Registers lazy WASM loader for web mode | N/A |
+| `isTauri()` | webtau-specific | Checks `window.__TAURI_INTERNALS__` | N/A |
+
+Common Tauri core APIs not implemented by this shim: `convertFileSrc`, `Channel`, callback/plugin helpers.
+
+## `webtau/window` vs `@tauri-apps/api/window`
+
+Top-level shim export:
+
+| Export | Status | Web behavior |
+|---|---|---|
+| `getCurrentWindow()` | Implemented | Returns singleton `WebWindow` shim |
+
+`WebWindow` methods:
+
+| Method | Status | Web behavior |
+|---|---|---|
+| `isFullscreen()` | Implemented | Uses `document.fullscreenElement` |
+| `setFullscreen(bool)` | Implemented | Uses Fullscreen API |
+| `innerSize()` / `outerSize()` | Implemented | Uses `window.innerWidth/innerHeight` and `window.outerWidth/outerHeight` |
+| `setSize(LogicalSize/PhysicalSize)` | Partial | Uses `window.resizeTo`, browser restrictions apply |
+| `maximize()` | Partial | Approximated via fullscreen |
+| `isMaximized()` | Partial | Mirrors fullscreen state |
+| `title()` / `setTitle()` | Implemented | Reads/writes `document.title` |
+| `close()` | Partial | Calls `window.close()`, browser may ignore |
+| `minimize()` / `unminimize()` | No-op | Not available in browser tabs |
+| `show()` / `hide()` | No-op | Not available in browser tabs |
+| `setDecorations(bool)` | No-op | Browser chrome not controllable from JS |
+| `center()` | Partial | Uses `window.moveTo`, browser restrictions apply |
+| `currentMonitor()` | Partial | Uses `screen.*` approximation |
+| `scaleFactor()` | Implemented | Uses `window.devicePixelRatio` |
+
+Common Tauri window APIs not implemented include advanced positioning, resizability flags, z-order/taskbar/dock integration, per-window event APIs, and platform-only controls.
+
+## `webtau/dpi` vs `@tauri-apps/api/dpi`
+
+| Export | Status | Web behavior |
+|---|---|---|
+| `LogicalSize` | Implemented | Includes `toPhysical(scaleFactor)` |
+| `PhysicalSize` | Implemented | Includes `toLogical(scaleFactor)` |
+| `LogicalPosition` | Implemented | Includes `toPhysical(scaleFactor)` |
+| `PhysicalPosition` | Implemented | Includes `toLogical(scaleFactor)` |
+
+## `webtau/fs` vs `@tauri-apps/api/fs`
+
+Backed by IndexedDB with in-memory fallback in non-browser test environments.
+
+| Export | Status | Web behavior |
+|---|---|---|
+| `writeTextFile` | Implemented | Stores text in virtual FS |
+| `readTextFile` | Implemented | Reads text from virtual FS |
+| `writeFile` | Implemented | Stores bytes in virtual FS |
+| `readFile` | Implemented | Reads bytes from virtual FS |
+| `exists` | Implemented | Checks virtual FS entries |
+| `mkdir` / `createDir` | Implemented | Creates virtual directory chain |
+| `readDir` | Implemented | Returns virtual directory entries |
+| `remove` / `removeDir` | Implemented | Removes virtual entries (supports recursive) |
+
+Common Tauri fs APIs not implemented include copy/rename/link/chmod/chown, direct path resolution against OS locations, and native permission model behavior.
+
+## `webtau/dialog` vs `@tauri-apps/api/dialog`
+
+| Export | Status | Web behavior |
+|---|---|---|
+| `message` | Implemented (partial) | Uses HTML `<dialog>` or `alert` fallback |
+| `ask` / `confirm` | Implemented (partial) | Uses HTML `<dialog>` or `confirm` fallback |
+| `open` | Implemented (partial) | Uses hidden `<input type="file">`; returns selected names/relative paths |
+| `save` | Implemented (partial) | Uses `<dialog>` text input or `prompt` fallback |
+
+Note: Desktop-native file-picker behavior and absolute filesystem paths are not available in standard browser context.
+
+## `webtau/event` vs `@tauri-apps/api/event`
+
+| Export | Status | Web behavior |
+|---|---|---|
+| `listen(event, cb)` | Implemented (partial) | Uses `window.addEventListener` or in-memory fallback |
+| `once(event, cb)` | Implemented (partial) | Auto-unlistens after first callback |
+| `emit(event, payload)` | Implemented (partial) | Uses `window.dispatchEvent(new CustomEvent(...))` |
+| `emitTo(target, event, payload)` | Partial | Alias of `emit` in web mode (no real target routing) |
+
+## `webtau/app` vs `@tauri-apps/api/app`
+
+| Export | Status | Web behavior | Tauri equivalent |
+|---|---|---|---|
+| `getName()` | Implemented (partial) | Configured name, else `document.title`, else `"gametau-app"` | `getName` |
+| `getVersion()` | Implemented (partial) | Configured version, else `"0.0.0"` | `getVersion` |
+| `getTauriVersion()` | Implemented (partial) | Returns `"web"` | `getTauriVersion` |
+| `show()` | No-op | Browser tabs cannot be shown programmatically | `show` |
+| `hide()` | No-op | Browser tabs cannot be hidden programmatically | `hide` |
+| `setAppName(name \| null)` | webtau-specific | Sets/clears fallback app name | N/A |
+| `setAppVersion(version \| null)` | webtau-specific | Sets/clears fallback app version | N/A |
+
+Current Tauri app APIs not implemented include `getIdentifier`, `defaultWindowIcon`, `setTheme`, data-store APIs, bundle-type APIs, dock visibility APIs, and Android back-button listener hooks.
+
+## `webtau/path` vs `@tauri-apps/api/path`
+
+Implemented exports:
+
+| Export | Status | Web behavior |
+|---|---|---|
+| `sep()` | Implemented | Always `/` |
+| `appDataDir` / `appLocalDataDir` / `appConfigDir` / `appCacheDir` / `appLogDir` | Partial | Virtual `/app/*` locations |
+| `desktopDir` / `documentDir` / `downloadDir` / `homeDir` / `audioDir` / `pictureDir` / `publicDir` / `videoDir` | Partial | Virtual `/app/*` locations |
+| `resourceDir` / `tempDir` | Partial | Virtual `/app/resources` and `/app/temp` |
+| `basename` / `dirname` / `extname` / `join` / `normalize` / `resolve` / `isAbsolute` | Implemented (POSIX-style) | Browser-safe path utilities |
+
+Tauri path APIs currently not implemented:
+- `delimiter()`
+- `cacheDir()`
+- `configDir()`
+- `dataDir()`
+- `localDataDir()`
+- `executableDir()`
+- `fontDir()`
+- `runtimeDir()`
+- `templateDir()`
+- `resolveResource(resourcePath)`
+
+---
+
+## Foundation Modules (No Tauri Equivalent)
+
+These modules are native `webtau` features and are not parity shims.
+
+| Module | Factory | Status | Purpose |
+|---|---|---|---|
+| `webtau/input` | `createInputController(options?)` | Implemented | Unified keyboard/gamepad/touch/pointer-lock input layer |
+| `webtau/audio` | `createAudioController(options?)` | Implemented | Minimal Web Audio controller with tone playback and master controls |
+| `webtau/assets` | `createAssetLoader(options?)` | Implemented | Cached text/json/bytes/image asset loading helpers |
+
+### `webtau/input` API
+
+| Method | Status | Behavior |
+|---|---|---|
+| `destroy()` | Implemented | Removes listeners and clears controller state |
+| `isPressed(key)` | Implemented | Returns keyboard pressed state |
+| `keyAxis(negative, positive)` | Implemented | Resolves digital axis from key bindings |
+| `gamepadAxis(axisIndex, options?)` | Implemented | Reads gamepad axis with deadzone/invert support |
+| `touches()` | Implemented | Returns active touch points |
+| `requestPointerLock(element)` | Implemented (partial) | Best-effort pointer-lock request in supported browsers |
+| `isPointerLocked(element?)` | Implemented | Reports pointer-lock state |
+| `consumePointerDelta()` | Implemented | Returns and resets accumulated pointer delta |
+
+### `webtau/audio` API
+
+| Method | Status | Behavior |
+|---|---|---|
+| `isSupported()` | Implemented | Indicates Web Audio availability |
+| `isMuted()` | Implemented | Returns mute state |
+| `setMuted(bool)` | Implemented | Toggles mute for controller output |
+| `getMasterVolume()` | Implemented | Returns current master volume (`0..1`) |
+| `setMasterVolume(value)` | Implemented | Sets/clamps master volume (`0..1`) |
+| `resume()` | Implemented | Resumes audio context when available |
+| `suspend()` | Implemented | Suspends audio context when available |
+| `playTone(freq, durationMs, options?)` | Implemented | Plays synthesized tone (no-op when muted/unsupported) |
+
+### `webtau/assets` API
+
+| Method | Status | Behavior |
+|---|---|---|
+| `clear()` | Implemented | Clears in-memory asset cache |
+| `loadText(url, init?)` | Implemented | Loads and caches text response |
+| `loadJson<T>(url, init?)` | Implemented | Loads text and parses JSON with cache |
+| `loadBytes(url, init?)` | Implemented | Loads and caches binary payload |
+| `loadImage(url)` | Implemented | Loads and caches image element |
+
+## References
+
+- Tauri v2 JavaScript API: <https://v2.tauri.app/reference/javascript/api/>
+- Path namespace reference: <https://v2.tauri.app/reference/javascript/api/namespacepath/>
+- App namespace reference: <https://v2.tauri.app/reference/javascript/api/namespaceapp/>

--- a/packages/create-gametau/package.json
+++ b/packages/create-gametau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-gametau",
-  "version": "0.2.1",
+  "version": "0.3.0-alpha.2",
   "description": "Scaffold a Tauri game that deploys to web + desktop",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-gametau/templates/base/package.json
+++ b/packages/create-gametau/templates/base/package.json
@@ -11,12 +11,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "webtau": "^0.2.0"
+    "webtau": "^0.3.0-alpha.2"
   },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.2.0",
+    "webtau-vite": "^0.3.0-alpha.2",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml
+++ b/packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 {{PROJECT_NAME}}-core = { path = "../core" }
-webtau = "0.2"
+webtau = "0.3.0-alpha.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tauri = { version = "2", features = [] }

--- a/packages/create-gametau/templates/base/src-tauri/wasm/Cargo.toml
+++ b/packages/create-gametau/templates/base/src-tauri/wasm/Cargo.toml
@@ -11,7 +11,7 @@ wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.2", features = ["js"] }
-webtau = "0.2"
+webtau = "0.3.0-alpha.2"
 {{PROJECT_NAME}}-core = { path = "../core" }
 {{PROJECT_NAME}}-commands = { path = "../commands" }
 

--- a/packages/create-gametau/templates/pixi/package.json
+++ b/packages/create-gametau/templates/pixi/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "pixi.js": "^8.0.0",
-    "webtau": "^0.2.0"
+    "webtau": "^0.3.0-alpha.2"
   },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.2.0",
+    "webtau-vite": "^0.3.0-alpha.2",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/create-gametau/templates/three/package.json
+++ b/packages/create-gametau/templates/three/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "three": "^0.172.0",
-    "webtau": "^0.2.0"
+    "webtau": "^0.3.0-alpha.2"
   },
   "devDependencies": {
     "@types/three": "^0.172.0",
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.2.0",
+    "webtau-vite": "^0.3.0-alpha.2",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/webtau-vite/package.json
+++ b/packages/webtau-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtau-vite",
-  "version": "0.2.1",
+  "version": "0.3.0-alpha.2",
   "description": "Vite plugin for webtau — wasm-pack automation + Tauri API aliasing",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/webtau/package.json
+++ b/packages/webtau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtau",
-  "version": "0.2.1",
+  "version": "0.3.0-alpha.2",
   "description": "Deploy Tauri games to web + desktop from one codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/webtau/src/app.test.ts
+++ b/packages/webtau/src/app.test.ts
@@ -12,22 +12,10 @@ import {
 const originalDocument = (globalThis as { document?: unknown }).document;
 
 afterEach(() => {
-  // Reset configured overrides by setting to a known name then clearing
-  // via the module's internal state. We re-import fresh state by calling
-  // the setters with values that restore defaults.
-  setAppName(null as unknown as string);
-  setAppVersion(null as unknown as string);
+  setAppName(null);
+  setAppVersion(null);
   (globalThis as { document?: unknown }).document = originalDocument;
 });
-
-// Re-set null after import to clear any leftover state — the setters
-// accept string but we exploit the null check internally.
-function clearOverrides() {
-  // The module stores null as "not configured" — we poke it back.
-  // This is safe because the module checks `!== null`.
-  (setAppName as (v: string | null) => void)(null);
-  (setAppVersion as (v: string | null) => void)(null);
-}
 
 describe("webtau/app", () => {
   // -- getName --
@@ -38,19 +26,22 @@ describe("webtau/app", () => {
   });
 
   test("getName falls back to document.title", async () => {
-    clearOverrides();
+    setAppName(null);
+    setAppVersion(null);
     (globalThis as { document?: unknown }).document = { title: "Browser Title" };
     expect(await getName()).toBe("Browser Title");
   });
 
   test("getName returns default when no title or config", async () => {
-    clearOverrides();
+    setAppName(null);
+    setAppVersion(null);
     (globalThis as { document?: unknown }).document = undefined;
     expect(await getName()).toBe("gametau-app");
   });
 
   test("getName returns default when document.title is empty", async () => {
-    clearOverrides();
+    setAppName(null);
+    setAppVersion(null);
     (globalThis as { document?: unknown }).document = { title: "" };
     expect(await getName()).toBe("gametau-app");
   });
@@ -63,7 +54,8 @@ describe("webtau/app", () => {
   });
 
   test("getVersion returns 0.0.0 by default", async () => {
-    clearOverrides();
+    setAppName(null);
+    setAppVersion(null);
     expect(await getVersion()).toBe("0.0.0");
   });
 

--- a/packages/webtau/src/app.ts
+++ b/packages/webtau/src/app.ts
@@ -13,25 +13,29 @@ let appVersion: string | null = null;
 /**
  * Override the app name returned by `getName()`.
  * Useful for setting metadata early in your web entry point.
+ * Pass `null` to reset to the default fallback behavior.
  *
  * ```ts
  * import { setAppName } from "webtau/app";
  * setAppName("My Game");
+ * setAppName(null); // reset
  * ```
  */
-export function setAppName(name: string): void {
+export function setAppName(name: string | null): void {
   appName = name;
 }
 
 /**
  * Override the app version returned by `getVersion()`.
+ * Pass `null` to reset to the default fallback behavior.
  *
  * ```ts
  * import { setAppVersion } from "webtau/app";
  * setAppVersion("1.2.0");
+ * setAppVersion(null); // reset
  * ```
  */
-export function setAppVersion(version: string): void {
+export function setAppVersion(version: string | null): void {
   appVersion = version;
 }
 


### PR DESCRIPTION
## Summary
- prepare `0.3.0-alpha.2` prerelease version alignment across workspace crates, npm packages, and scaffold templates
- add a new public parity matrix at `docs/PARITY-MATRIX.md` and wire parity guidance into README/getting-started docs
- clean up `webtau/app` setter typing to support safe `null` resets without type-unsafe test casts

## Test plan
- [x] `bun test --cwd packages/webtau` (115 pass)
- [x] `bun test --cwd packages/webtau-vite` (24 pass)
- [x] `bun test --cwd packages/create-gametau` (17 pass)
- [x] `bunx tsc --noEmit -p packages/webtau/tsconfig.json`
- [x] `bunx tsc --noEmit -p packages/webtau-vite/tsconfig.json`
- [x] `bunx tsc --noEmit -p packages/create-gametau/tsconfig.json`
- [x] `cargo check --workspace`
- [x] manifest sweep confirms no stale `0.2.1` / `^0.2.0` / `webtau = 0.2`

Closes #23