### PR TITLE
feat(create-gametau): uplift template services and release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,13 @@ jobs:
           echo "Expected output: tarball metadata + file list and exit code 0."
           cd packages/create-gametau
           npm pack --dry-run
+
+  release-gate-contract:
+    name: Release Gate Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify canonical gate docs exist
+        run: |
+          test -f docs/RELEASE-GATE-CHECKLIST.md
+          test -f docs/RELEASE-INCIDENT-RESPONSE.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -259,3 +259,56 @@ jobs:
           test -d smoke-game/dist
           test -f smoke-game/dist/index.html
           echo "Consumer smoke test passed for v${VERSION}"
+
+  release-evidence:
+    name: Release Evidence Bundle
+    needs: [publish-npm, publish-crate, verify-publish, consumer-smoke]
+    if: >-
+      always() && !cancelled() &&
+      needs.verify-publish.result == 'success' &&
+      needs.consumer-smoke.result == 'success' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (needs.publish-npm.result == 'success' && needs.publish-crate.result == 'success')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          echo "VERSION=${version}" >> "$GITHUB_ENV"
+
+      - name: Build evidence markdown
+        env:
+          PUBLISH_NPM_RESULT: ${{ needs.publish-npm.result }}
+          PUBLISH_CRATE_RESULT: ${{ needs.publish-crate.result }}
+          VERIFY_RESULT: ${{ needs.verify-publish.result }}
+          CONSUMER_SMOKE_RESULT: ${{ needs.consumer-smoke.result }}
+        run: |
+          mkdir -p .release-evidence
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat <<EOF > ".release-evidence/release-evidence-v${VERSION}.md"
+          # Release Evidence — v${VERSION}
+
+          ## Workflow Summary
+          - Run URL: ${run_url}
+          - publish-npm: ${PUBLISH_NPM_RESULT}
+          - publish-crate: ${PUBLISH_CRATE_RESULT}
+          - verify-publish: ${VERIFY_RESULT}
+          - consumer-smoke: ${CONSUMER_SMOKE_RESULT}
+
+          ## Required Gate References
+          - Tag: v${VERSION}
+          - Workflow run: ${run_url}
+          - Checklist source: docs/RELEASE-GATE-CHECKLIST.md
+          EOF
+          cat ".release-evidence/release-evidence-v${VERSION}.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence-v${{ env.VERSION }}
+          path: .release-evidence

--- a/README.md
+++ b/README.md
@@ -441,6 +441,10 @@ my-game/
     game/scene.ts           # Three.js / PixiJS / Canvas2D scene
     game/loop.ts            # requestAnimationFrame + tick integration
     services/backend.ts     # Typed invoke() wrappers
+    services/settings.ts    # Runtime settings persistence (webtau/path + webtau/fs)
+    services/session.ts     # Mission/session snapshots (webtau/path + webtau/fs)
+    services/comms.ts       # Event-driven comms/alerts (webtau/event)
+    services/contracts.ts   # Service-layer interfaces and shared types
   package.json
   vite.config.ts            # Pre-configured with webtau-vite
 ```
@@ -641,7 +645,7 @@ Manual v1 wrappers remain fully supported — you can migrate command-by-command
 
 ## Roadmap
 
-- **`0.2.x` (shipped, current stable line)**: docs/adoption + parity/foundation backlog is delivered (tutorial, API docs pipeline, release incident checklist, `fs/dialog/event` shims, and `input/audio/assets` modules). See [CHANGELOG `0.2.1`](./CHANGELOG.md#021---2026-02-26) and [roadmap issue #6](https://github.com/devallibus/gametau/issues/6).
+- **`0.2.x` (shipped, current stable line)**: docs/adoption + parity/foundation backlog is delivered (tutorial, API docs pipeline, release gate + incident checklists, `fs/dialog/event` shims, and `input/audio/assets` modules). See [CHANGELOG `0.2.1`](./CHANGELOG.md#021---2026-02-26) and [roadmap issue #6](https://github.com/devallibus/gametau/issues/6).
 - **`0.3.0-alpha.2` (current prerelease line)**: `app/path` runtime parity shims are shipped and documented; production ergonomics and public parity narrative continue under [roadmap issue #28](https://github.com/devallibus/gametau/issues/28).
 - **`0.3.0` (planned stable milestone)**: deepen runtime surface and production ergonomics (module maturation, parity expansion, and adoption hardening).
 - **`0.4.0+` (future)**: broader platform capabilities and ecosystem expansion.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -101,5 +101,5 @@ Before expanding your game, check current runtime parity and API surface:
 ## 9) Next Steps
 
 - Read architecture details in `README.md`
-- Review release/incident procedures in `docs/RELEASE-INCIDENT-RESPONSE.md`
+- Review release gating + incident procedures in `docs/RELEASE-GATE-CHECKLIST.md` and `docs/RELEASE-INCIDENT-RESPONSE.md`
 - Explore examples in `examples/counter` and `examples/pong`

--- a/docs/RELEASE-GATE-CHECKLIST.md
+++ b/docs/RELEASE-GATE-CHECKLIST.md
@@ -1,0 +1,47 @@
+# Release Gate Checklist
+
+Use this as the canonical gate artifact for `0.3.0+` releases. It complements
+`docs/RELEASE-INCIDENT-RESPONSE.md` by defining what must be true *before* and
+*after* tagging.
+
+## 1) Pre-Tag Gate (On `master`)
+
+- [ ] Scope issues are closed (or explicitly deferred with notes).
+- [ ] `CI` run on `master` is green (`MSRV`, `Rust`, `TypeScript`, `API Docs`, `Scaffold & Build Smoke`, `Publish Preflight`).
+- [ ] `create-gametau` template architecture checks pass (service seams + scaffold tests).
+- [ ] `CHANGELOG.md`, `README.md`, and docs reflect the release narrative and compatibility notes.
+- [ ] Version manifests are aligned across workspace crates, npm packages, and templates.
+
+## 2) Tag + Publish Gate
+
+- [ ] Tag is created once (`vX.Y.Z`) and never rewritten.
+- [ ] GitHub release is created with summary + migration/adoption notes.
+- [ ] `Publish` workflow completes `publish-npm` and `publish-crate` successfully.
+- [ ] `Verify Published Artifacts` job confirms npm + crates installability.
+- [ ] `Consumer Smoke Test` passes using published registry artifacts.
+
+## 3) Evidence Bundle (Required Links)
+
+For each release, capture these links in the release issue/roadmap update:
+
+- [ ] Merge PR(s) used for release preparation
+- [ ] Tag URL
+- [ ] GitHub release URL
+- [ ] `Publish` workflow run URL
+- [ ] Registry verification job URL
+- [ ] Consumer smoke job URL
+- [ ] Any follow-up risk/mitigation notes
+
+## 4) Post-Publish Gate
+
+- [ ] Roadmap/release tracking issue updated with: decision log, implementation evidence, adoption guidance, risk note.
+- [ ] If any artifact is superseded/broken, publish a fix-forward patch and deprecate affected npm versions.
+- [ ] Roadmap umbrella issue remains open until all planned workstreams are complete.
+
+## 5) Sign-Off
+
+Record sign-off in the release tracking thread:
+
+- [ ] Engineering sign-off
+- [ ] CI/release gate sign-off
+- [ ] Roadmap state sign-off

--- a/docs/RELEASE-INCIDENT-RESPONSE.md
+++ b/docs/RELEASE-INCIDENT-RESPONSE.md
@@ -1,6 +1,7 @@
 # Release Incident Response Checklist
 
 Use this checklist when a tag-triggered `Publish` workflow fails or when release artifacts are partially published.
+For normal release gating before/after tag cut, use `docs/RELEASE-GATE-CHECKLIST.md`.
 
 ## 1) Freeze and Capture Evidence
 
@@ -53,6 +54,7 @@ Apply this to each superseded version that should no longer be installed by user
 
 - `CI` on `master` is green.
 - `Publish Preflight` checks pass (`cargo publish --dry-run`, `npm pack --dry-run`).
+- `docs/RELEASE-GATE-CHECKLIST.md` pre-tag items are complete.
 - Release tracking issues are updated with:
   - failing run reference
   - fix commits

--- a/packages/create-gametau/README.md
+++ b/packages/create-gametau/README.md
@@ -38,6 +38,19 @@ bunx create-gametau my-game --template vanilla
 - `src-tauri/app` - Tauri desktop shell
 - `src-tauri/wasm` - WASM entry crate
 - `src` - frontend app wired to `webtau` and `webtau-vite`
+- `src/services` - production-ready service seams for backend invoke calls, persistence/settings, mission session snapshots, and event-driven comms
+
+## Service Layer Contract
+
+The scaffolded base template now ships a small service architecture instead of a single command wrapper:
+
+- `src/services/backend.ts` - typed `invoke()` wrappers for gameplay commands
+- `src/services/settings.ts` - runtime settings persistence via `webtau/path` + `webtau/fs`
+- `src/services/session.ts` - mission/session snapshot persistence via `webtau/path` + `webtau/fs`
+- `src/services/comms.ts` - typed alert/comms channel over `webtau/event`
+- `src/services/contracts.ts` - interfaces/types for settings, session snapshots, and alerts
+
+This keeps the generated project lightweight while giving contributors clear extension points for production features.
 
 For full docs and package details, see the main repository:
 <https://github.com/devallibus/gametau>

--- a/packages/create-gametau/src/cli.test.ts
+++ b/packages/create-gametau/src/cli.test.ts
@@ -153,6 +153,11 @@ describe("create-gametau CLI", () => {
     expect(existsSync(join(projectDir, "src-tauri", "commands", "src", "lib.rs"))).toBe(true);
     expect(existsSync(join(projectDir, "src-tauri", "commands", "src", "commands.rs"))).toBe(true);
     expect(existsSync(join(projectDir, "src", "game", "scene.ts"))).toBe(true);
+    expect(existsSync(join(projectDir, "src", "services", "index.ts"))).toBe(true);
+    expect(existsSync(join(projectDir, "src", "services", "contracts.ts"))).toBe(true);
+    expect(existsSync(join(projectDir, "src", "services", "settings.ts"))).toBe(true);
+    expect(existsSync(join(projectDir, "src", "services", "session.ts"))).toBe(true);
+    expect(existsSync(join(projectDir, "src", "services", "comms.ts"))).toBe(true);
     expect(existsSync(join(projectDir, ".gitignore"))).toBe(true);
     expect(existsSync(join(projectDir, ".npmignore"))).toBe(false);
     expect(existsSync(join(projectDir, "gitignore"))).toBe(false);
@@ -228,6 +233,31 @@ describe("create-gametau CLI", () => {
     expect(viteConfig).not.toContain("wasmCrate:");
     expect(viteConfig).not.toContain("wasmOutDir:");
     expect(viteConfig).not.toContain("watchPaths:");
+  });
+
+  test("service seam modules align to fs/path/event parity shims", () => {
+    const dir = freshDir();
+    scaffold({ projectName: "service-seams", template: "three" }, dir);
+    const projectDir = join(dir, "service-seams");
+
+    const settingsService = readFileSync(
+      join(projectDir, "src", "services", "settings.ts"),
+      "utf-8",
+    );
+    const sessionService = readFileSync(
+      join(projectDir, "src", "services", "session.ts"),
+      "utf-8",
+    );
+    const commsService = readFileSync(
+      join(projectDir, "src", "services", "comms.ts"),
+      "utf-8",
+    );
+
+    expect(settingsService).toContain("webtau/fs");
+    expect(settingsService).toContain("webtau/path");
+    expect(sessionService).toContain("webtau/fs");
+    expect(sessionService).toContain("webtau/path");
+    expect(commsService).toContain("webtau/event");
   });
 
   test("no {{PROJECT_NAME}} placeholders remain in any file", () => {

--- a/packages/create-gametau/templates/base/index.html
+++ b/packages/create-gametau/templates/base/index.html
@@ -25,6 +25,10 @@
     <div id="hud">
       <div>Score: <span id="score">0</span></div>
       <div>Tick: <span id="tick">0</span></div>
+      <div>Tick Rate: <span id="tick-rate">0</span> Hz</div>
+      <div>Autosave: every <span id="autosave">0</span> ticks</div>
+      <div>Session: <span id="session">fresh</span></div>
+      <div>Alert: <span id="alert">ready</span></div>
     </div>
     <div id="app"></div>
     <script type="module" src="/src/index.ts"></script>

--- a/packages/create-gametau/templates/base/src/services/comms.ts
+++ b/packages/create-gametau/templates/base/src/services/comms.ts
@@ -1,0 +1,32 @@
+import { emit, listen } from "webtau/event";
+import type { AlertMessage, CommsService } from "./contracts";
+
+const COMMS_NAMESPACE = "gametau:comms";
+
+function eventNameFor(channel: string): string {
+  return `${COMMS_NAMESPACE}:${channel}`;
+}
+
+export function createCommsService(channel: string): CommsService {
+  const eventName = eventNameFor(channel);
+
+  return {
+    channel,
+
+    async publish(input): Promise<void> {
+      const payload: AlertMessage = {
+        level: input.level,
+        source: input.source,
+        message: input.message,
+        timestamp: input.timestamp ?? new Date().toISOString(),
+      };
+      await emit(eventName, payload);
+    },
+
+    async subscribe(handler): Promise<() => void> {
+      return listen<AlertMessage>(eventName, ({ payload }) => {
+        handler(payload);
+      });
+    },
+  };
+}

--- a/packages/create-gametau/templates/base/src/services/contracts.ts
+++ b/packages/create-gametau/templates/base/src/services/contracts.ts
@@ -1,0 +1,48 @@
+import type { WorldView } from "./backend";
+
+export type AlertLevel = "info" | "warning" | "critical";
+
+export interface AlertMessage {
+  level: AlertLevel;
+  source: string;
+  message: string;
+  timestamp: string;
+}
+
+export interface RuntimeSettings {
+  tickRateHz: number;
+  autoSaveEveryTicks: number;
+  commsChannel: string;
+}
+
+export const DEFAULT_RUNTIME_SETTINGS: RuntimeSettings = {
+  tickRateHz: 10,
+  autoSaveEveryTicks: 10,
+  commsChannel: "ops",
+};
+
+export interface SessionSnapshot extends WorldView {
+  savedAt: string;
+}
+
+export interface SettingsService {
+  load(): Promise<RuntimeSettings>;
+  save(next: Partial<RuntimeSettings>): Promise<RuntimeSettings>;
+}
+
+export interface SessionService {
+  loadLastSnapshot(): Promise<SessionSnapshot | null>;
+  saveSnapshot(view: WorldView): Promise<void>;
+}
+
+export interface CommsService {
+  readonly channel: string;
+  publish(input: Omit<AlertMessage, "timestamp"> & { timestamp?: string }): Promise<void>;
+  subscribe(handler: (message: AlertMessage) => void): Promise<() => void>;
+}
+
+export interface ServiceLayer {
+  settings: SettingsService;
+  session: SessionService;
+  comms: CommsService;
+}

--- a/packages/create-gametau/templates/base/src/services/index.ts
+++ b/packages/create-gametau/templates/base/src/services/index.ts
@@ -1,0 +1,28 @@
+import { createCommsService } from "./comms";
+import {
+  DEFAULT_RUNTIME_SETTINGS,
+  type AlertLevel,
+  type AlertMessage,
+  type RuntimeSettings,
+  type SessionSnapshot,
+  type ServiceLayer,
+} from "./contracts";
+import { createSessionService } from "./session";
+import { createSettingsService } from "./settings";
+
+export * from "./backend";
+export {
+  DEFAULT_RUNTIME_SETTINGS,
+  type RuntimeSettings,
+  type AlertLevel,
+  type AlertMessage,
+  type SessionSnapshot,
+};
+
+export async function createServiceLayer(): Promise<ServiceLayer> {
+  const settings = createSettingsService();
+  const resolvedSettings = await settings.load();
+  const comms = createCommsService(resolvedSettings.commsChannel);
+  const session = createSessionService();
+  return { settings, comms, session };
+}

--- a/packages/create-gametau/templates/base/src/services/session.ts
+++ b/packages/create-gametau/templates/base/src/services/session.ts
@@ -1,0 +1,59 @@
+import { createDir, exists, readTextFile, writeTextFile } from "webtau/fs";
+import { appDataDir, join } from "webtau/path";
+import type { SessionService, SessionSnapshot } from "./contracts";
+import type { WorldView } from "./backend";
+
+const SESSION_FILENAME = "mission-session.json";
+
+function toSnapshot(view: WorldView): SessionSnapshot {
+  return {
+    ...view,
+    savedAt: new Date().toISOString(),
+  };
+}
+
+function parseSnapshot(raw: unknown): SessionSnapshot | null {
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as Partial<SessionSnapshot>;
+  if (
+    typeof candidate.score !== "number" ||
+    typeof candidate.tick_count !== "number" ||
+    typeof candidate.savedAt !== "string"
+  ) {
+    return null;
+  }
+  return {
+    score: candidate.score,
+    tick_count: candidate.tick_count,
+    savedAt: candidate.savedAt,
+  };
+}
+
+async function getSessionPath(): Promise<string> {
+  const dataDir = await appDataDir();
+  await createDir(dataDir, { recursive: true });
+  return join(dataDir, SESSION_FILENAME);
+}
+
+export function createSessionService(): SessionService {
+  return {
+    async loadLastSnapshot(): Promise<SessionSnapshot | null> {
+      const sessionPath = await getSessionPath();
+      if (!(await exists(sessionPath))) {
+        return null;
+      }
+      try {
+        const raw = await readTextFile(sessionPath);
+        return parseSnapshot(JSON.parse(raw) as unknown);
+      } catch {
+        return null;
+      }
+    },
+
+    async saveSnapshot(view: WorldView): Promise<void> {
+      const sessionPath = await getSessionPath();
+      const snapshot = toSnapshot(view);
+      await writeTextFile(sessionPath, JSON.stringify(snapshot, null, 2));
+    },
+  };
+}

--- a/packages/create-gametau/templates/base/src/services/settings.ts
+++ b/packages/create-gametau/templates/base/src/services/settings.ts
@@ -1,0 +1,69 @@
+import { createDir, exists, readTextFile, writeTextFile } from "webtau/fs";
+import { appConfigDir, join } from "webtau/path";
+import {
+  DEFAULT_RUNTIME_SETTINGS,
+  type RuntimeSettings,
+  type SettingsService,
+} from "./contracts";
+
+const SETTINGS_FILENAME = "runtime-settings.json";
+
+function normalizeSettings(raw: unknown): RuntimeSettings {
+  if (!raw || typeof raw !== "object") {
+    return DEFAULT_RUNTIME_SETTINGS;
+  }
+  const candidate = raw as Partial<RuntimeSettings>;
+  const tickRateHz =
+    typeof candidate.tickRateHz === "number" && Number.isFinite(candidate.tickRateHz)
+      ? Math.max(1, Math.floor(candidate.tickRateHz))
+      : DEFAULT_RUNTIME_SETTINGS.tickRateHz;
+  const autoSaveEveryTicks =
+    typeof candidate.autoSaveEveryTicks === "number" && Number.isFinite(candidate.autoSaveEveryTicks)
+      ? Math.max(1, Math.floor(candidate.autoSaveEveryTicks))
+      : DEFAULT_RUNTIME_SETTINGS.autoSaveEveryTicks;
+  const commsChannel =
+    typeof candidate.commsChannel === "string" && candidate.commsChannel.trim().length > 0
+      ? candidate.commsChannel.trim()
+      : DEFAULT_RUNTIME_SETTINGS.commsChannel;
+
+  return { tickRateHz, autoSaveEveryTicks, commsChannel };
+}
+
+async function getSettingsPath(): Promise<string> {
+  const configDir = await appConfigDir();
+  await createDir(configDir, { recursive: true });
+  return join(configDir, SETTINGS_FILENAME);
+}
+
+export function createSettingsService(): SettingsService {
+  let cache: RuntimeSettings | null = null;
+
+  return {
+    async load(): Promise<RuntimeSettings> {
+      if (cache) return cache;
+
+      const settingsPath = await getSettingsPath();
+      if (!(await exists(settingsPath))) {
+        cache = DEFAULT_RUNTIME_SETTINGS;
+        return cache;
+      }
+
+      try {
+        const raw = await readTextFile(settingsPath);
+        cache = normalizeSettings(JSON.parse(raw) as unknown);
+      } catch {
+        cache = DEFAULT_RUNTIME_SETTINGS;
+      }
+      return cache;
+    },
+
+    async save(next: Partial<RuntimeSettings>): Promise<RuntimeSettings> {
+      const current = await this.load();
+      const merged = normalizeSettings({ ...current, ...next });
+      const settingsPath = await getSettingsPath();
+      await writeTextFile(settingsPath, JSON.stringify(merged, null, 2));
+      cache = merged;
+      return merged;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- uplift `create-gametau` base template to a production-oriented service layer (`backend`, `settings`, `session`, `comms`, shared contracts)
- wire scaffold runtime to persistence/comms seams powered by `webtau/path`, `webtau/fs`, and `webtau/event`
- add canonical release gate documentation and a publish `Release Evidence Bundle` job for externally auditable release reporting

## Test plan
- [x] `bun test` (packages/create-gametau)
- [x] `bunx tsc --noEmit -p packages/create-gametau/tsconfig.json`
- [ ] local scaffold `build:web` smoke (blocked by missing local `wasm-pack`; CI smoke covers this path)

Closes #24
Closes #25