### PR TITLE
chore(release): prepare stable v0.3.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - 2026-02-27
+
+### Added
+- Battlestation flagship showcase example (`examples/battlestation`) covering the full module story (`input`, `audio`, `assets`, `fs/path`, `event`, `app`) across web + desktop
+- Public battlestation design and reuse docs: `docs/BATTLESTATION-DESIGN-BRIEF.md` and `docs/BATTLESTATION-SHOWCASE.md`
+- Canonical stable release gate artifact in `docs/RELEASE-GATE-CHECKLIST.md` plus publish-time `Release Evidence Bundle` workflow artifact
+
+### Changed
+- Workspace, crate, npm package, and template dependency versions moved from prerelease to stable `0.3.0`
+- `create-gametau` templates now ship a production-oriented service layer (`settings`, `session`, `comms`, shared contracts) as default extension seams
+- CI wasm codegen checks now include `examples/battlestation`
+- README/Getting Started examples list now positions battlestation as flagship showcase
+
+### Stabilized
+- `app/path` parity shims, parity matrix docs, and release evidence discipline from the `0.3.0-alpha.2` line are now part of stable `0.3.0`
+
 ## [0.3.0-alpha.2] - 2026-02-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.77"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -674,9 +674,8 @@ Manual v1 wrappers remain fully supported — you can migrate command-by-command
 
 ## Roadmap
 
-- **`0.2.x` (shipped, current stable line)**: docs/adoption + parity/foundation backlog is delivered (tutorial, API docs pipeline, release gate + incident checklists, `fs/dialog/event` shims, and `input/audio/assets` modules). See [CHANGELOG `0.2.1`](./CHANGELOG.md#021---2026-02-26) and [roadmap issue #6](https://github.com/devallibus/gametau/issues/6).
-- **`0.3.0-alpha.2` (current prerelease line)**: `app/path` runtime parity shims are shipped and documented; production ergonomics and public parity narrative continue under [roadmap issue #28](https://github.com/devallibus/gametau/issues/28).
-- **`0.3.0` (planned stable milestone)**: deepen runtime surface and production ergonomics (module maturation, parity expansion, and adoption hardening).
+- **`0.2.x` (historical stable line)**: docs/adoption + parity/foundation backlog delivered (`fs/dialog/event` shims and `input/audio/assets` modules). See [CHANGELOG `0.2.1`](./CHANGELOG.md#021---2026-02-26) and [roadmap issue #6](https://github.com/devallibus/gametau/issues/6).
+- **`0.3.0` (shipped, current stable line)**: runtime parity expansion (`app/path`), scaffold production ergonomics (service-layer templates + release gate discipline), and flagship battlestation showcase are delivered under [roadmap issue #28](https://github.com/devallibus/gametau/issues/28).
 - **`0.4.0+` (future)**: broader platform capabilities and ecosystem expansion.
 
 ## Support & Commercial Licensing

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "packages/create-gametau": {
       "name": "create-gametau",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0",
       "bin": {
         "create-gametau": "dist/cli.js",
       },
@@ -64,7 +64,7 @@
     },
     "packages/webtau": {
       "name": "webtau",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0",
       "devDependencies": {
         "@types/bun": "^1.2.0",
         "typescript": "^5.8.0",
@@ -78,7 +78,7 @@
     },
     "packages/webtau-vite": {
       "name": "webtau-vite",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0",
       "dependencies": {
         "chokidar": "^4.0.0",
       },

--- a/crates/webtau/Cargo.toml
+++ b/crates/webtau/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-webtau-macros = { path = "../webtau-macros", version = "=0.3.0-alpha.2" }
+webtau-macros = { path = "../webtau-macros", version = "=0.3.0" }

--- a/docs/PARITY-MATRIX.md
+++ b/docs/PARITY-MATRIX.md
@@ -13,7 +13,7 @@ Scope:
 - `Partial`: API name exists, but semantics differ from native Tauri behavior.
 - `Not implemented`: available in Tauri but not provided by current `webtau` shim.
 
-## Coverage Summary (v0.3.0-alpha.2)
+## Coverage Summary (v0.3.0)
 
 Coverage is an approximate function-level view of each aliased namespace.
 

--- a/packages/create-gametau/package.json
+++ b/packages/create-gametau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-gametau",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0",
   "description": "Scaffold a Tauri game that deploys to web + desktop",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-gametau/templates/base/package.json
+++ b/packages/create-gametau/templates/base/package.json
@@ -11,12 +11,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "webtau": "^0.3.0-alpha.2"
+    "webtau": "^0.3.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.3.0-alpha.2",
+    "webtau-vite": "^0.3.0",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml
+++ b/packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 {{PROJECT_NAME}}-core = { path = "../core" }
-webtau = "0.3.0-alpha.2"
+webtau = "0.3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tauri = { version = "2", features = [] }

--- a/packages/create-gametau/templates/base/src-tauri/wasm/Cargo.toml
+++ b/packages/create-gametau/templates/base/src-tauri/wasm/Cargo.toml
@@ -11,7 +11,7 @@ wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.2", features = ["js"] }
-webtau = "0.3.0-alpha.2"
+webtau = "0.3.0"
 {{PROJECT_NAME}}-core = { path = "../core" }
 {{PROJECT_NAME}}-commands = { path = "../commands" }
 

--- a/packages/create-gametau/templates/pixi/package.json
+++ b/packages/create-gametau/templates/pixi/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "pixi.js": "^8.0.0",
-    "webtau": "^0.3.0-alpha.2"
+    "webtau": "^0.3.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.3.0-alpha.2",
+    "webtau-vite": "^0.3.0",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/create-gametau/templates/three/package.json
+++ b/packages/create-gametau/templates/three/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "three": "^0.172.0",
-    "webtau": "^0.3.0-alpha.2"
+    "webtau": "^0.3.0"
   },
   "devDependencies": {
     "@types/three": "^0.172.0",
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.3.0-alpha.2",
+    "webtau-vite": "^0.3.0",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/webtau-vite/package.json
+++ b/packages/webtau-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtau-vite",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0",
   "description": "Vite plugin for webtau — wasm-pack automation + Tauri API aliasing",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/webtau/package.json
+++ b/packages/webtau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtau",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0",
   "description": "Deploy Tauri games to web + desktop from one codebase",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- promote workspace/crate/npm/template version manifests from `0.3.0-alpha.2` to stable `0.3.0`
- add a stable `0.3.0` changelog entry and align README roadmap + parity matrix wording to the shipped stable line
- keep historical `0.3.0-alpha.2` release notes intact while updating lock metadata for stable publish resolution

## Test plan
- [x] `bun test` in `packages/webtau`
- [x] `bun test` in `packages/webtau-vite`
- [x] `bun test` in `packages/create-gametau`
- [x] `bunx tsc --noEmit -p packages/webtau/tsconfig.json`
- [x] `bunx tsc --noEmit -p packages/webtau-vite/tsconfig.json`
- [x] `bunx tsc --noEmit -p packages/create-gametau/tsconfig.json`
- [x] `cargo check --workspace`
- [x] `cargo check --target wasm32-unknown-unknown -p counter-commands --manifest-path examples/counter/src-tauri/Cargo.toml`
- [x] `cargo check --target wasm32-unknown-unknown -p pong-commands --manifest-path examples/pong/src-tauri/Cargo.toml`
- [x] `cargo check --target wasm32-unknown-unknown -p battlestation-commands --manifest-path examples/battlestation/src-tauri/Cargo.toml`