### PR TITLE
feat(site): add Tailwind CSS v4 with Vite build pipeline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,11 +60,16 @@ jobs:
         working-directory: examples/battlestation
         run: bunx vite build --base=/gametau/battlestation/
 
+      # Build site
+      - name: Build site
+        working-directory: site
+        run: bunx vite build
+
       # Assemble site
       - name: Assemble site
         run: |
           mkdir -p _site
-          cp site/index.html _site/
+          cp -r site/dist/* _site/
           cp -r .api-docs _site/api
           cp -r examples/counter/dist _site/counter
           cp -r examples/pong/dist _site/pong

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,15 @@
         "vite": ">=5.0.0",
       },
     },
+    "site": {
+      "name": "site",
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.0",
+        "tailwindcss": "^4.1.0",
+        "typescript": "^5.8.0",
+        "vite": "^6.2.0",
+      },
+    },
   },
   "packages": {
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
@@ -145,6 +154,16 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
     "@pixi/colord": ["@pixi/colord@2.9.6", "", {}, "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
@@ -197,6 +216,36 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.1", "@tailwindcss/oxide-darwin-arm64": "4.2.1", "@tailwindcss/oxide-darwin-x64": "4.2.1", "@tailwindcss/oxide-freebsd-x64": "4.2.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1", "@tailwindcss/oxide-linux-arm64-musl": "4.2.1", "@tailwindcss/oxide-linux-x64-gnu": "4.2.1", "@tailwindcss/oxide-linux-x64-musl": "4.2.1", "@tailwindcss/oxide-wasm32-wasi": "4.2.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1", "@tailwindcss/oxide-win32-x64-msvc": "4.2.1" } }, "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.1", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
+
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@tauri-apps/cli": ["@tauri-apps/cli@2.10.0", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.10.0", "@tauri-apps/cli-darwin-x64": "2.10.0", "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.0", "@tauri-apps/cli-linux-arm64-gnu": "2.10.0", "@tauri-apps/cli-linux-arm64-musl": "2.10.0", "@tauri-apps/cli-linux-riscv64-gnu": "2.10.0", "@tauri-apps/cli-linux-x64-gnu": "2.10.0", "@tauri-apps/cli-linux-x64-musl": "2.10.0", "@tauri-apps/cli-win32-arm64-msvc": "2.10.0", "@tauri-apps/cli-win32-ia32-msvc": "2.10.0", "@tauri-apps/cli-win32-x64-msvc": "2.10.0" }, "bin": { "tauri": "tauri.js" } }, "sha512-ZwT0T+7bw4+DPCSWzmviwq5XbXlM0cNoleDKOYPFYqcZqeKY31KlpoMW/MOON/tOFBPgi31a2v3w9gliqwL2+Q=="],
@@ -245,7 +294,11 @@
 
     "create-gametau": ["create-gametau@workspace:packages/create-gametau"],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "earcut": ["earcut@3.0.2", "", {}, "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -257,9 +310,39 @@
 
     "gifuct-js": ["gifuct-js@2.1.2", "", { "dependencies": { "js-binary-schema-parser": "^2.0.3" } }, "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg=="],
 
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
     "ismobilejs": ["ismobilejs@1.1.1", "", {}, "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="],
 
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
     "js-binary-schema-parser": ["js-binary-schema-parser@2.0.3", "", {}, "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg=="],
+
+    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -279,7 +362,13 @@
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
+    "site": ["site@workspace:site"],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
+
+    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "tiny-lru": ["tiny-lru@11.4.7", "", {}, "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw=="],
 
@@ -308,5 +397,17 @@
     "webtau": ["webtau@workspace:packages/webtau"],
 
     "webtau-vite": ["webtau-vite@workspace:packages/webtau-vite"],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "packageManager": "bun@1.3.9",
   "workspaces": [
     "packages/*",
-    "examples/*"
+    "examples/*",
+    "site"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/site/index.html
+++ b/site/index.html
@@ -10,461 +10,110 @@
     <meta property="og:url" content="https://devallibus.github.io/gametau/" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary" />
-    <style>
-      * { margin: 0; padding: 0; box-sizing: border-box; }
-
-      :root {
-        --bg: #0a0a1a;
-        --bg-card: #12122a;
-        --accent: #00d4aa;
-        --accent-dim: #00a885;
-        --text: #e0e0e0;
-        --text-muted: #999;
-        --text-dim: #666;
-        --border: #222;
-        --max-w: 1000px;
-      }
-
-      body {
-        font-family: system-ui, -apple-system, sans-serif;
-        background: var(--bg);
-        color: var(--text);
-        line-height: 1.6;
-      }
-
-      a { color: var(--accent); text-decoration: none; }
-      a:hover { text-decoration: underline; }
-
-      code {
-        font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-        background: rgba(255,255,255,0.06);
-        padding: 0.15em 0.4em;
-        border-radius: 4px;
-        font-size: 0.9em;
-      }
-
-      /* ── Hero ─────────────────────────────────────── */
-
-      .hero {
-        text-align: center;
-        padding: 6rem 1.5rem 4rem;
-      }
-
-      .hero h1 {
-        font-size: clamp(2.5rem, 6vw, 4rem);
-        color: #fff;
-        letter-spacing: -0.02em;
-        margin-bottom: 1rem;
-      }
-
-      .hero .tagline {
-        font-size: clamp(1rem, 2.5vw, 1.25rem);
-        color: var(--text-muted);
-        max-width: 600px;
-        margin: 0 auto 2.5rem;
-      }
-
-      .hero-buttons {
-        display: flex;
-        gap: 1rem;
-        justify-content: center;
-        flex-wrap: wrap;
-      }
-
-      .btn {
-        display: inline-block;
-        padding: 0.8rem 2rem;
-        border-radius: 8px;
-        font-size: 1rem;
-        font-weight: 600;
-        text-decoration: none;
-        transition: transform 0.15s, box-shadow 0.15s;
-      }
-
-      .btn:hover {
-        transform: translateY(-1px);
-        text-decoration: none;
-      }
-
-      .btn-primary {
-        background: var(--accent);
-        color: var(--bg);
-      }
-
-      .btn-primary:hover {
-        box-shadow: 0 4px 20px rgba(0,212,170,0.3);
-      }
-
-      .btn-secondary {
-        background: transparent;
-        color: var(--accent);
-        border: 1px solid var(--accent);
-      }
-
-      .btn-secondary:hover {
-        background: rgba(0,212,170,0.08);
-      }
-
-      /* ── Sections (shared) ──────────────────────── */
-
-      section {
-        padding: 4rem 1.5rem;
-        max-width: var(--max-w);
-        margin: 0 auto;
-      }
-
-      section h2 {
-        font-size: 1.8rem;
-        color: #fff;
-        text-align: center;
-        margin-bottom: 2.5rem;
-      }
-
-      /* ── How It Works ───────────────────────────── */
-
-      .how-it-works-diagram {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 1.5rem;
-        margin: 0 auto;
-        max-width: 700px;
-      }
-
-      .diagram-box {
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: 10px;
-        padding: 1rem 2rem;
-        text-align: center;
-        font-weight: 600;
-        width: 100%;
-        max-width: 320px;
-      }
-
-      .diagram-box.core {
-        border-color: var(--accent);
-        color: var(--accent);
-      }
-
-      .diagram-arrow {
-        color: var(--text-dim);
-        font-size: 1.5rem;
-        line-height: 1;
-      }
-
-      .diagram-split {
-        display: flex;
-        gap: 2rem;
-        justify-content: center;
-        flex-wrap: wrap;
-        width: 100%;
-      }
-
-      .diagram-split .diagram-box {
-        flex: 1;
-        min-width: 200px;
-      }
-
-      .diagram-box small {
-        display: block;
-        font-weight: 400;
-        color: var(--text-dim);
-        font-size: 0.85rem;
-        margin-top: 0.3rem;
-      }
-
-      .diagram-invoke {
-        background: var(--bg-card);
-        border: 1px solid var(--accent);
-        border-radius: 10px;
-        padding: 1rem 2rem;
-        text-align: center;
-        width: 100%;
-        max-width: 500px;
-      }
-
-      .diagram-invoke code {
-        color: var(--accent);
-        font-size: 1.05rem;
-        background: none;
-        padding: 0;
-      }
-
-      .diagram-invoke small {
-        display: block;
-        color: var(--text-dim);
-        font-size: 0.85rem;
-        margin-top: 0.3rem;
-      }
-
-      /* ── Features Grid ──────────────────────────── */
-
-      .features-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1.5rem;
-      }
-
-      .feature-card {
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 1.5rem;
-      }
-
-      .feature-card h3 {
-        color: var(--accent);
-        font-size: 1.1rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .feature-card p {
-        color: var(--text-muted);
-        font-size: 0.92rem;
-        line-height: 1.5;
-      }
-
-      /* ── Quick Start ────────────────────────────── */
-
-      .quickstart {
-        text-align: center;
-      }
-
-      .quickstart-cmd {
-        display: inline-block;
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: 10px;
-        padding: 1.2rem 2.5rem;
-        font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-        font-size: clamp(0.9rem, 2vw, 1.15rem);
-        color: var(--accent);
-        margin-bottom: 1.5rem;
-        letter-spacing: -0.01em;
-        user-select: all;
-      }
-
-      .quickstart-cmd span {
-        color: var(--text-dim);
-      }
-
-      .templates {
-        color: var(--text-muted);
-        font-size: 0.95rem;
-        line-height: 1.8;
-      }
-
-      .templates code {
-        color: var(--text);
-      }
-
-      /* ── Demos ──────────────────────────────────── */
-
-      .demos-grid {
-        display: flex;
-        gap: 2rem;
-        flex-wrap: wrap;
-        justify-content: center;
-      }
-
-      .demo-card {
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 2rem;
-        width: 320px;
-        text-decoration: none;
-        color: inherit;
-        transition: border-color 0.2s, transform 0.2s;
-        display: block;
-      }
-
-      .demo-card:hover {
-        border-color: var(--accent);
-        transform: translateY(-2px);
-        text-decoration: none;
-      }
-
-      .demo-card h3 {
-        font-size: 1.3rem;
-        color: var(--accent);
-        margin-bottom: 0.5rem;
-      }
-
-      .demo-card p {
-        color: var(--text-muted);
-        font-size: 0.92rem;
-        line-height: 1.5;
-      }
-
-      .demo-card .tech {
-        margin-top: 1rem;
-        font-size: 0.8rem;
-        color: var(--text-dim);
-      }
-
-      /* ── Packages ───────────────────────────────── */
-
-      .packages-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 0.95rem;
-      }
-
-      .packages-table th,
-      .packages-table td {
-        text-align: left;
-        padding: 0.75rem 1rem;
-        border-bottom: 1px solid var(--border);
-      }
-
-      .packages-table th {
-        color: var(--text-dim);
-        font-weight: 600;
-        font-size: 0.8rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-
-      .packages-table td a {
-        font-weight: 500;
-      }
-
-      /* ── Footer ─────────────────────────────────── */
-
-      footer {
-        text-align: center;
-        padding: 3rem 1.5rem 2rem;
-        font-size: 0.85rem;
-        color: var(--text-dim);
-        border-top: 1px solid var(--border);
-        max-width: var(--max-w);
-        margin: 2rem auto 0;
-      }
-
-      footer .links {
-        margin-bottom: 0.75rem;
-      }
-
-      footer .links a {
-        margin: 0 0.75rem;
-      }
-
-      /* ── Responsive ─────────────────────────────── */
-
-      @media (max-width: 600px) {
-        .hero { padding: 4rem 1rem 3rem; }
-        section { padding: 3rem 1rem; }
-        .diagram-split { flex-direction: column; align-items: center; }
-        .quickstart-cmd { padding: 1rem 1.2rem; }
-        .demo-card { width: 100%; }
-      }
-    </style>
   </head>
   <body>
 
     <!-- ── Hero ──────────────────────────────────── -->
-    <header class="hero">
-      <h1>gametau</h1>
-      <p class="tagline">
+    <header class="text-center pt-24 pb-16 px-6 max-sm:pt-16 max-sm:pb-12 max-sm:px-4">
+      <h1 class="text-[clamp(2.5rem,6vw,4rem)] text-white tracking-tight mb-4">gametau</h1>
+      <p class="text-[clamp(1rem,2.5vw,1.25rem)] text-text-muted max-w-[600px] mx-auto mb-10">
         Write game logic once in Rust. Ship native to Steam.
         Keep the web build for itch.io. Develop in Chrome with hot-reload.
       </p>
-      <div class="hero-buttons">
-        <a class="btn btn-primary" href="https://github.com/devallibus/gametau#quick-start">Get Started</a>
-        <a class="btn btn-secondary" href="./battlestation/">Try Battlestation</a>
-        <a class="btn btn-secondary" href="./api/">API Docs</a>
+      <div class="flex gap-4 justify-center flex-wrap">
+        <a class="btn bg-accent text-bg hover:shadow-[0_4px_20px_rgba(0,212,170,0.3)]" href="https://github.com/devallibus/gametau#quick-start">Get Started</a>
+        <a class="btn bg-transparent text-accent border border-accent hover:bg-accent/[0.08]" href="./battlestation/">Try Battlestation</a>
+        <a class="btn bg-transparent text-accent border border-accent hover:bg-accent/[0.08]" href="./api/">API Docs</a>
       </div>
     </header>
 
     <!-- ── How It Works ──────────────────────────── -->
-    <section>
-      <h2>How It Works</h2>
-      <div class="how-it-works-diagram">
-        <div class="diagram-box core">core/ (Rust)<small>Pure game logic &mdash; no framework deps</small></div>
-        <div class="diagram-arrow">&darr;</div>
-        <div class="diagram-split">
-          <div class="diagram-box">Tauri (desktop)<small>#[tauri::command] &rarr; native IPC</small></div>
-          <div class="diagram-box">WASM (browser)<small>#[wasm_bindgen] &rarr; direct call</small></div>
+    <section class="section">
+      <h2 class="section-heading">How It Works</h2>
+      <div class="flex flex-col items-center gap-6 mx-auto max-w-[700px]">
+        <div class="bg-bg-card border border-accent rounded-box py-4 px-8 text-center font-semibold w-full max-w-[320px] text-accent">core/ (Rust)<small class="block font-normal text-text-dim text-[0.85rem] mt-1">Pure game logic &mdash; no framework deps</small></div>
+        <div class="text-text-dim text-2xl leading-none">&darr;</div>
+        <div class="flex gap-8 justify-center flex-wrap w-full max-sm:flex-col max-sm:items-center">
+          <div class="bg-bg-card border border-border rounded-box py-4 px-8 text-center font-semibold flex-1 min-w-[200px] max-w-[320px]">Tauri (desktop)<small class="block font-normal text-text-dim text-[0.85rem] mt-1">#[tauri::command] &rarr; native IPC</small></div>
+          <div class="bg-bg-card border border-border rounded-box py-4 px-8 text-center font-semibold flex-1 min-w-[200px] max-w-[320px]">WASM (browser)<small class="block font-normal text-text-dim text-[0.85rem] mt-1">#[wasm_bindgen] &rarr; direct call</small></div>
         </div>
-        <div class="diagram-arrow">&darr;</div>
-        <div class="diagram-invoke">
-          <code>invoke("tick_world")</code>
-          <small>Same frontend code. Auto-routes at runtime.</small>
+        <div class="text-text-dim text-2xl leading-none">&darr;</div>
+        <div class="bg-bg-card border border-accent rounded-box py-4 px-8 text-center w-full max-w-[500px]">
+          <code class="text-accent text-[1.05rem] bg-transparent p-0">invoke("tick_world")</code>
+          <small class="block text-text-dim text-[0.85rem] mt-1">Same frontend code. Auto-routes at runtime.</small>
         </div>
       </div>
     </section>
 
     <!-- ── Why gametau? ──────────────────────────── -->
-    <section>
-      <h2>Why gametau?</h2>
-      <div class="features-grid">
-        <div class="feature-card">
-          <h3>Dev in Chrome</h3>
-          <p>Full DevTools, hot-reload, shareable dev URLs. Drop into <code>tauri dev</code> only when testing desktop-specific behavior.</p>
+    <section class="section">
+      <h2 class="section-heading">Why gametau?</h2>
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-6">
+        <div class="bg-bg-card border border-border rounded-card p-6">
+          <h3 class="text-accent text-[1.1rem] mb-2">Dev in Chrome</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">Full DevTools, hot-reload, shareable dev URLs. Drop into <code>tauri dev</code> only when testing desktop-specific behavior.</p>
         </div>
-        <div class="feature-card">
-          <h3>No GC Pauses</h3>
-          <p>Rust has no garbage collector. Your simulation ticks at a consistent cost every frame, not whenever JS decides to collect.</p>
+        <div class="bg-bg-card border border-border rounded-card p-6">
+          <h3 class="text-accent text-[1.1rem] mb-2">No GC Pauses</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">Rust has no garbage collector. Your simulation ticks at a consistent cost every frame, not whenever JS decides to collect.</p>
         </div>
-        <div class="feature-card">
-          <h3>2-5x Faster Physics</h3>
-          <p>Physics, pathfinding, and large entity counts run measurably faster in WASM than equivalent JS. On desktop, it's full native code.</p>
+        <div class="bg-bg-card border border-border rounded-card p-6">
+          <h3 class="text-accent text-[1.1rem] mb-2">2-5x Faster Physics</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">Physics, pathfinding, and large entity counts run measurably faster in WASM than equivalent JS. On desktop, it's full native code.</p>
         </div>
-        <div class="feature-card">
-          <h3>Portable Core</h3>
-          <p>The <code>core/</code> crate has zero framework dependencies. Reuse it for a multiplayer server, a new target, or anywhere else.</p>
+        <div class="bg-bg-card border border-border rounded-card p-6">
+          <h3 class="text-accent text-[1.1rem] mb-2">Portable Core</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">The <code>core/</code> crate has zero framework dependencies. Reuse it for a multiplayer server, a new target, or anywhere else.</p>
         </div>
       </div>
     </section>
 
     <!-- ── Quick Start ───────────────────────────── -->
-    <section class="quickstart">
-      <h2>Quick Start</h2>
-      <div class="quickstart-cmd"><span>$</span> bunx create-gametau my-game</div>
-      <div class="templates">
-        Templates: <code>-t three</code> (default) &middot; <code>-t pixi</code> &middot; <code>-t vanilla</code>
+    <section class="section text-center">
+      <h2 class="section-heading">Quick Start</h2>
+      <div class="inline-block bg-bg-card border border-border rounded-box py-[1.2rem] px-10 font-mono text-[clamp(0.9rem,2vw,1.15rem)] text-accent mb-6 tracking-[-0.01em] select-all max-sm:py-4 max-sm:px-5"><span class="text-text-dim">$</span> bunx create-gametau my-game</div>
+      <div class="text-text-muted text-[0.95rem] leading-[1.8]">
+        Templates: <code class="text-text">-t three</code> (default) &middot; <code class="text-text">-t pixi</code> &middot; <code class="text-text">-t vanilla</code>
       </div>
     </section>
 
     <!-- ── Live Demos ────────────────────────────── -->
-    <section>
-      <h2>Live Demos</h2>
-      <div class="demos-grid">
-        <a class="demo-card" href="./battlestation/">
-          <h3>Battlestation</h3>
-          <p>
+    <section class="section">
+      <h2 class="section-heading">Live Demos</h2>
+      <div class="flex gap-8 flex-wrap justify-center">
+        <a class="block bg-bg-card border border-border rounded-card p-8 w-80 no-underline text-inherit transition-[border-color,transform] duration-200 hover:border-accent hover:-translate-y-0.5 hover:no-underline max-sm:w-full" href="./battlestation/">
+          <h3 class="text-[1.3rem] text-accent mb-2">Battlestation</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">
             Flagship tactical radar command loop. Exercises runtime bridge,
             app metadata, local profile persistence, asset loading, and alert
             event orchestration in one end-to-end scenario.
           </p>
-          <div class="tech">Rust + Canvas2D + full webtau module story</div>
+          <div class="mt-4 text-[0.8rem] text-text-dim">Rust + Canvas2D + full webtau module story</div>
         </a>
-        <a class="demo-card" href="./counter/">
-          <h3>Counter</h3>
-          <p>
+        <a class="block bg-bg-card border border-border rounded-card p-8 w-80 no-underline text-inherit transition-[border-color,transform] duration-200 hover:border-accent hover:-translate-y-0.5 hover:no-underline max-sm:w-full" href="./counter/">
+          <h3 class="text-[1.3rem] text-accent mb-2">Counter</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">
             Simplest possible example. Increment, decrement, reset &mdash;
             Rust logic called through the same <code>invoke()</code> API
             that works on both web and desktop.
           </p>
-          <div class="tech">Rust + vanilla DOM</div>
+          <div class="mt-4 text-[0.8rem] text-text-dim">Rust + vanilla DOM</div>
         </a>
-        <a class="demo-card" href="./pong/">
-          <h3>Pong</h3>
-          <p>
+        <a class="block bg-bg-card border border-border rounded-card p-8 w-80 no-underline text-inherit transition-[border-color,transform] duration-200 hover:border-accent hover:-translate-y-0.5 hover:no-underline max-sm:w-full" href="./pong/">
+          <h3 class="text-[1.3rem] text-accent mb-2">Pong</h3>
+          <p class="text-text-muted text-[0.92rem] leading-normal">
             Two-player Pong with real physics. Ball collision, paddle clamping,
             score tracking &mdash; all in Rust, rendered with PixiJS at 60fps.
           </p>
-          <div class="tech">Rust + PixiJS</div>
+          <div class="mt-4 text-[0.8rem] text-text-dim">Rust + PixiJS</div>
         </a>
       </div>
     </section>
 
     <!-- ── Packages ──────────────────────────────── -->
-    <section>
-      <h2>Packages</h2>
-      <table class="packages-table">
+    <section class="section">
+      <h2 class="section-heading">Packages</h2>
+      <table class="pkg-table w-full border-collapse text-[0.95rem]">
         <thead>
           <tr>
             <th>Package</th>
@@ -474,22 +123,22 @@
         </thead>
         <tbody>
           <tr>
-            <td><a href="https://crates.io/crates/webtau">webtau</a></td>
+            <td><a href="https://crates.io/crates/webtau" class="font-medium">webtau</a></td>
             <td>crates.io</td>
             <td><code>wasm_state!</code> macro for WASM state management</td>
           </tr>
           <tr>
-            <td><a href="https://npmjs.com/package/webtau">webtau</a></td>
+            <td><a href="https://npmjs.com/package/webtau" class="font-medium">webtau</a></td>
             <td>npm</td>
             <td><code>invoke()</code> router + Tauri API shims</td>
           </tr>
           <tr>
-            <td><a href="https://npmjs.com/package/webtau-vite">webtau-vite</a></td>
+            <td><a href="https://npmjs.com/package/webtau-vite" class="font-medium">webtau-vite</a></td>
             <td>npm</td>
             <td>Vite plugin: wasm-pack automation + import aliasing</td>
           </tr>
           <tr>
-            <td><a href="https://npmjs.com/package/create-gametau">create-gametau</a></td>
+            <td><a href="https://npmjs.com/package/create-gametau" class="font-medium">create-gametau</a></td>
             <td>npm</td>
             <td>Project scaffolder CLI</td>
           </tr>
@@ -498,15 +147,16 @@
     </section>
 
     <!-- ── Footer ────────────────────────────────── -->
-    <footer>
-      <div class="links">
-        <a href="https://github.com/devallibus/gametau">GitHub</a>
-        <a href="https://npmjs.com/package/webtau">npm</a>
-        <a href="https://crates.io/crates/webtau">crates.io</a>
-        <a href="./api/">API docs</a>
+    <footer class="text-center pt-12 pb-8 px-6 text-[0.85rem] text-text-dim border-t border-border max-w-content mt-8 mx-auto">
+      <div class="mb-3">
+        <a class="mx-3" href="https://github.com/devallibus/gametau">GitHub</a>
+        <a class="mx-3" href="https://npmjs.com/package/webtau">npm</a>
+        <a class="mx-3" href="https://crates.io/crates/webtau">crates.io</a>
+        <a class="mx-3" href="./api/">API docs</a>
       </div>
       <div>Apache-2.0 License</div>
     </footer>
 
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "site",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.0",
+    "tailwindcss": "^4.1.0",
+    "typescript": "^5.8.0",
+    "vite": "^6.2.0"
+  }
+}

--- a/site/src/main.css
+++ b/site/src/main.css
@@ -1,0 +1,34 @@
+@import "tailwindcss";
+
+@theme {
+  --color-bg:         #0a0a1a;
+  --color-bg-card:    #12122a;
+  --color-accent:     #00d4aa;
+  --color-accent-dim: #00a885;
+  --color-text:       #e0e0e0;
+  --color-text-muted: #999999;
+  --color-text-dim:   #666666;
+  --color-border:     #222222;
+  --breakpoint-sm:    600px;
+  --max-width-content: 1000px;
+  --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --radius-card: 12px;
+  --radius-box:  10px;
+  --radius-btn:  8px;
+  --radius-code: 4px;
+}
+
+@layer base {
+  body   { @apply bg-bg text-text font-sans leading-[1.6]; }
+  a      { @apply text-accent no-underline; }
+  a:hover { @apply underline; }
+  code   { @apply font-mono bg-white/[0.06] px-[0.4em] py-[0.15em] rounded-code text-[0.9em]; }
+}
+
+@layer components {
+  .btn { @apply inline-block py-[0.8rem] px-8 rounded-btn text-base font-semibold no-underline transition-[transform,box-shadow] duration-150 hover:-translate-y-px hover:no-underline; }
+  .section { @apply py-16 px-6 max-w-content mx-auto max-sm:py-12 max-sm:px-4; }
+  .section-heading { @apply text-[1.8rem] text-white text-center mb-10; }
+  .pkg-table th { @apply text-left py-3 px-4 border-b border-border text-text-dim font-semibold text-[0.8rem] uppercase tracking-wider; }
+  .pkg-table td { @apply text-left py-3 px-4 border-b border-border; }
+}

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -1,0 +1,1 @@
+import "./main.css";

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,0 +1,7 @@
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: process.env.NODE_ENV === "production" ? "/gametau/" : "/",
+  plugins: [tailwindcss()],
+});


### PR DESCRIPTION
## Summary
- Replace ~350 lines of inline CSS in `site/index.html` with Tailwind CSS v4 utility classes
- Add Vite dev server with HMR for local development (`bun run dev` in `site/`)
- Production build outputs minified, hashed CSS/JS assets with `/gametau/` base path
- Update GitHub Pages workflow to build `site/` via Vite before assembling `_site/`

Closes #46

## Changes
| File | What |
|------|------|
| `site/package.json` | New workspace — `tailwindcss`, `@tailwindcss/vite`, `vite`, `typescript` |
| `site/vite.config.ts` | Tailwind plugin + conditional base path |
| `site/tsconfig.json` | Minimal editor config (`noEmit`) |
| `site/src/main.css` | Tailwind entry with `@theme` tokens, base & component layers |
| `site/src/main.ts` | JS entry — just imports the CSS |
| `site/index.html` | Stripped `<style>` block, applied Tailwind utility classes |
| `package.json` | Added `"site"` to workspaces |
| `.github/workflows/pages.yml` | Added Vite build step, copy `site/dist/*` to `_site/` |

## Test plan
- [ ] `cd site && bun run dev` — landing page renders at localhost:5173
- [ ] `cd site && bun run build` — `site/dist/index.html` has hashed assets with `/gametau/` prefix
- [ ] Visual comparison of every section (hero, diagram, features, quickstart, demos, table, footer) at desktop and mobile widths
- [ ] GitHub Actions workflow deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)