### PR TITLE
fix(webtau-vite): harden wasm-pack fallback for v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,31 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Verify webtau-vite fallback path without wasm-pack
+        run: |
+          cd packages/create-gametau/.pack-smoke/smoke-game
+
+          # Ensure the initial web build produced reusable wasm-pack artifacts.
+          test -d src/wasm
+          ls src/wasm/*_bg.wasm >/dev/null
+          ls src/wasm/*.js >/dev/null
+
+          path_without_cargo="$(python3 - <<'PY'
+          import os
+          path_entries = os.environ["PATH"].split(":")
+          filtered = [p for p in path_entries if not p.endswith("/.cargo/bin")]
+          print(":".join(filtered))
+          PY
+          )"
+
+          fallback_log="$(mktemp)"
+          env PATH="$path_without_cargo" bun run build:web 2>&1 | tee "$fallback_log"
+
+          if [[ "$(cat "$fallback_log")" != *"Reusing existing WASM output"* ]]; then
+            echo "Expected fallback warning was not emitted when wasm-pack was unavailable."
+            exit 1
+          fi
+
       - name: Build battlestation example (web target)
         run: |
           cd examples/battlestation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Site stack now includes Tailwind CSS v4 with Vite pipeline wiring
+- Battlestation radar renderer migrated from Canvas2D to Three.js with phase-2 visual polish
+
+### Changed
+- Battlestation now uses responsive layout and DPR-aware canvas sizing for sharper rendering across viewport sizes
+
+### Fixed
+- `webtau-vite` now supports graceful fallback: when `wasm-pack` is unavailable and valid prebuilt artifacts exist, web builds/dev startup reuse them instead of hard-failing
+- `webtau-vite` fallback validation is stricter (paired `*_bg.wasm` + loader `.js` output) and fails fast when reusable artifacts are missing or incomplete
+- `webtau-vite` dev Rust watch rebuilds now clearly disable in fallback mode; `wasm-pack` remains required for fresh Rust/WASM builds and rebuild loops
+
 ## [0.3.0] - 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then follow [Migrating an Existing Tauri Game](#migrating-an-existing-tauri-game
 ### Prerequisites
 
 - [Rust](https://rustup.rs/) with `wasm32-unknown-unknown` target
-- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) (required for fresh Rust/WASM builds and Rust watch rebuilds)
 - [Bun](https://bun.sh/) (or Node.js 18+)
 - [Tauri CLI](https://v2.tauri.app/start/create-project/) (for desktop builds only)
 
@@ -435,6 +435,13 @@ webtauVite({
   wasmOpt: false,                    // Run wasm-opt on release (default)
 })
 ```
+
+### `wasm-pack` requirement and fallback semantics
+
+- Fresh Rust/WASM builds and the dev rebuild loop require `wasm-pack`.
+- If `wasm-pack` is missing but valid prebuilt output already exists in `wasmOutDir`, `webtau-vite` reuses it and continues.
+- In this fallback mode, Rust watch rebuilds are intentionally disabled until `wasm-pack` is installed.
+- If `wasm-pack` is missing and reusable prebuilt artifacts are unavailable or incomplete, the plugin fails fast with a clear error.
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -5,7 +5,7 @@ This guide walks you from a fresh scaffold to a playable game loop in both brows
 ## 1) Prerequisites
 
 - Rust (with `wasm32-unknown-unknown`)
-- `wasm-pack`
+- `wasm-pack` (required for fresh Rust/WASM builds and Rust watch rebuilds)
 - Bun (or Node 18+)
 - Tauri CLI (for desktop run path)
 
@@ -68,6 +68,8 @@ let delta = self.rng.gen_range(1..=5);
 ```
 
 Save and refresh the browser. `Score` should now climb faster, proving the Rust gameplay path is active in web mode.
+
+Note: if `wasm-pack` is unavailable but you already have valid prebuilt `src/wasm` artifacts, web builds can still run in fallback mode. In that mode, Rust watch rebuilds are disabled until `wasm-pack` is installed.
 
 ## 6) Run in Tauri Desktop Mode
 


### PR DESCRIPTION
## Summary
- harden `webtau-vite` fallback validation to require reusable wasm-pack artifact pairs (`*_bg.wasm` + loader `.js`)
- unify missing-`wasm-pack` decisions across `buildStart()` and `configureServer()` so dev/build behavior stays deterministic
- expand fallback contract tests, add CI fallback regression coverage, and align README/Getting Started messaging

## Test plan
- [x] `bun run test` in `packages/webtau-vite`
- [x] `bunx tsc --noEmit -p packages/webtau-vite/tsconfig.json`
- [ ] CI workflow (`.github/workflows/ci.yml`) passes on PR

Refs #52