### PR TITLE
chore: generated artifact ignore policy (#56)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ Thumbs.db
 __test_output__/
 .api-docs/
 
+# Generated artifacts (not versioned)
+.playwright-mcp/
+**/src-tauri/app/gen/
+
 # Env
 .env
 .env.*

--- a/docs/RELEASE-GATE-CHECKLIST.md
+++ b/docs/RELEASE-GATE-CHECKLIST.md
@@ -11,6 +11,7 @@ Use this as the canonical gate artifact for `0.3.0+` releases. It complements
 - [ ] `create-gametau` template architecture checks pass (service seams + scaffold tests).
 - [ ] `CHANGELOG.md`, `README.md`, and docs reflect the release narrative and compatibility notes.
 - [ ] Version manifests are aligned across workspace crates, npm packages, and templates.
+- [ ] Local working tree is clean: `git status` shows no untracked generated artifacts (`.playwright-mcp/`, `**/src-tauri/app/gen/`)
 
 ## 2) Tag + Publish Gate
 


### PR DESCRIPTION
## Scope
Fixes #56. Adds `.gitignore` entries for two untracked generated directories and documents the policy in the release gate checklist.

## Files Changed
- `.gitignore` — added `.playwright-mcp/` and `**/src-tauri/app/gen/`
- `docs/RELEASE-GATE-CHECKLIST.md` — added pre-tag gate check for clean working tree

## Validation
- `.gitignore` entries confirmed
- Both paths no longer appear in `git status`

## Risk Notes
- Pure additive `.gitignore` change, no behavioral impact
- Paths were untracked (`??`), no `git rm --cached` needed

## Follow-ups
None — standalone hygiene patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)