### PR TITLE
test(battlestation): add scenario smoke tests for core sim (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
       - run: cargo clippy --workspace -- -D warnings
+      - name: Battlestation scenario smoke
+        run: cargo test -p battlestation-core --lib --manifest-path examples/battlestation/src-tauri/Cargo.toml
       - name: Check WASM codegen (wasm32 target)
         run: |
           cargo check --target wasm32-unknown-unknown -p counter-commands --manifest-path examples/counter/src-tauri/Cargo.toml


### PR DESCRIPTION
## Scope
Fixes #60. Adds 4 deterministic scenario smoke tests to the battlestation Rust core and a CI step to run them.

## Files Changed
- `examples/battlestation/src-tauri/core/src/lib.rs` — added `#[cfg(test)]` scenario tests
- `.github/workflows/ci.yml` — added "Battlestation scenario smoke" step to rust job

## Scenario Tests
1. `happy_path_kill_enemy_and_score` — ticks sim, fires until kill, asserts score increase
2. `failure_path_integrity_reaches_zero` — ticks without firing, asserts mission fails
3. `cycle_target_wraps_around` — cycles targets forward and back, asserts wrap
4. `fire_at_position_hits_nearby_enemy` — fires at enemy coordinates, asserts hit

## Validation
- All 12 tests pass (8 existing + 4 new)
- CI YAML syntax verified

## Risk Notes
- `#[cfg(test)]` module has zero production impact
- Tests are deterministic (tick-based, no RNG)

## Follow-ups
None — tests guard command-contract regressions going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)