### PR TITLE
ci: add Cloudflare staging deploy flow from development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, development]
   pull_request:
-    branches: [master]
+    branches: [master, development]
   workflow_call:
 
 permissions:

--- a/.github/workflows/staging-cloudflare.yml
+++ b/.github/workflows/staging-cloudflare.yml
@@ -1,0 +1,108 @@
+name: Deploy Staging to Cloudflare Pages
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-pages-staging
+  cancel-in-progress: true
+
+env:
+  STAGING_SITE_BASE_PATH: /
+  STAGING_COUNTER_BASE_PATH: /counter/
+  STAGING_PONG_BASE_PATH: /pong/
+  STAGING_BATTLESTATION_BASE_PATH: /battlestation/
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - run: bun install
+
+      - name: Generate API docs (TypeDoc + rustdoc)
+        run: bun run docs:api
+
+      - name: Build packages
+        run: |
+          cd packages/webtau && bun run build
+          cd ../webtau-vite && bun run build
+          cd ../create-gametau && bun run build
+
+      - name: Build counter (staging)
+        working-directory: examples/counter
+        run: bunx vite build --base=${{ env.STAGING_COUNTER_BASE_PATH }}
+
+      - name: Build pong (staging)
+        working-directory: examples/pong
+        run: bunx vite build --base=${{ env.STAGING_PONG_BASE_PATH }}
+
+      - name: Build battlestation (staging)
+        working-directory: examples/battlestation
+        run: bunx vite build --base=${{ env.STAGING_BATTLESTATION_BASE_PATH }}
+
+      - name: Build site (staging)
+        working-directory: site
+        run: SITE_BASE_PATH=${{ env.STAGING_SITE_BASE_PATH }} bunx vite build
+
+      - name: Assemble site artifact
+        run: |
+          mkdir -p _site
+          cp -r site/dist/* _site/
+          cp -r .api-docs _site/api
+          cp -r examples/counter/dist _site/counter
+          cp -r examples/pong/dist _site/pong
+          cp -r examples/battlestation/dist _site/battlestation
+
+      - name: Validate Cloudflare staging configuration
+        env:
+          CF_PROJECT: ${{ vars.CLOUDFLARE_PAGES_STAGING_PROJECT }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CF_PROJECT" ]; then
+            echo "Missing repository variable: CLOUDFLARE_PAGES_STAGING_PROJECT"
+            exit 1
+          fi
+          if [ -z "$CF_ACCOUNT" ]; then
+            echo "Missing repository secret: CLOUDFLARE_ACCOUNT_ID"
+            exit 1
+          fi
+          if [ -z "$CF_TOKEN" ]; then
+            echo "Missing repository secret: CLOUDFLARE_API_TOKEN"
+            exit 1
+          fi
+
+      - name: Deploy _site to Cloudflare Pages (staging)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy _site --project-name=${{ vars.CLOUDFLARE_PAGES_STAGING_PROJECT }} --branch=development
+
+      - name: Upload staging artifact (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-site-artifact
+          path: _site
+          if-no-files-found: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,20 @@ Please open an issue before submitting a PR for any of the following:
 3. **Use conventional commits**: `feat:`, `fix:`, `chore:`, `docs:`, etc.
 4. **Keep PRs focused** — one concern per PR.
 
+## Branch and environment flow
+
+- `feature/*` branches target `development`.
+- `development` is the integration branch and staging deployment source.
+- `master` is the production release branch.
+- Promote from `development` to `master` with a focused PR after staging validation.
+
+Staging deployment uses `.github/workflows/staging-cloudflare.yml` and requires:
+
+- Repository variable: `CLOUDFLARE_PAGES_STAGING_PROJECT`
+- Repository secrets: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`
+
+See `docs/STAGING-DEPLOYMENT.md` for setup and validation steps.
+
 ## CI Publish Preflight Expectations
 
 The CI workflow includes a **Publish Preflight** job to catch release regressions before tags are pushed.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ For the experimental Electrobun trial flow, see `docs/ELECTROBUN-EXPERIMENTAL.md
 - Live API docs: <https://devallibus.github.io/gametau/api/>
 - Generated automatically from TypeDoc + rustdoc in CI and published via GitHub Pages.
 
+### Environments and branches
+
+- `master` is production release/publish source.
+- `development` is integration + staging source.
+- Production site deploy: `.github/workflows/pages.yml` (GitHub Pages).
+- Staging deploy: `.github/workflows/staging-cloudflare.yml` (Cloudflare Pages direct upload).
+- Cloudflare staging deploy expects:
+  - Repository variable: `CLOUDFLARE_PAGES_STAGING_PROJECT`
+  - Repository secrets: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`
+- Full setup guide: `docs/STAGING-DEPLOYMENT.md`
+
 ### Existing Tauri project
 
 ```bash

--- a/docs/RELEASE-GATE-CHECKLIST.md
+++ b/docs/RELEASE-GATE-CHECKLIST.md
@@ -6,6 +6,7 @@ Use this as the canonical gate artifact for `0.3.0+` releases. It complements
 
 ## 1) Pre-Tag Gate (On `master`)
 
+- [ ] Candidate release was promoted from `development` after staging validation (Cloudflare staging deploy green).
 - [ ] Scope issues are closed (or explicitly deferred with notes).
 - [ ] `CI` run on `master` is green (`MSRV`, `Rust`, `TypeScript`, `API Docs`, `Scaffold & Build Smoke`, `Publish Preflight`).
 - [ ] `create-gametau` template architecture checks pass (service seams + scaffold tests).

--- a/docs/STAGING-DEPLOYMENT.md
+++ b/docs/STAGING-DEPLOYMENT.md
@@ -1,0 +1,64 @@
+# Staging Deployment (Cloudflare Pages)
+
+This guide describes the `development` -> Cloudflare staging flow.
+
+## Deployment model
+
+- Production:
+  - Branch: `master`
+  - Workflow: `.github/workflows/pages.yml`
+  - Host: GitHub Pages
+- Staging:
+  - Branch: `development`
+  - Workflow: `.github/workflows/staging-cloudflare.yml`
+  - Host: Cloudflare Pages (custom domain)
+
+## One-time Cloudflare setup
+
+1. Create a Cloudflare Pages project (Direct Upload compatible), for example:
+   - `gametau-staging`
+2. Attach your custom staging domain in Cloudflare Pages project settings.
+3. Ensure DNS is managed in Cloudflare for the staging hostname.
+
+## One-time GitHub setup
+
+Set these in the repository:
+
+- Variable:
+  - `CLOUDFLARE_PAGES_STAGING_PROJECT` = your Pages project name
+- Secrets:
+  - `CLOUDFLARE_ACCOUNT_ID`
+  - `CLOUDFLARE_API_TOKEN`
+
+Minimum token permissions should allow Pages deployments for the target account/project.
+
+## Runtime behavior
+
+`staging-cloudflare.yml` builds:
+
+- `site` with `SITE_BASE_PATH=/`
+- examples with root-relative paths:
+  - `/counter/`
+  - `/pong/`
+  - `/battlestation/`
+
+Then it assembles `_site` and deploys with:
+
+```bash
+wrangler pages deploy _site --project-name <project> --branch development
+```
+
+## Verification checklist
+
+- Push a no-op commit to `development`.
+- Confirm `Deploy Staging to Cloudflare Pages` workflow is green.
+- Open staging domain and verify:
+  - `/` (site shell)
+  - `/api/` (API docs)
+  - `/counter/`, `/pong/`, `/battlestation/`
+
+## Troubleshooting
+
+- Missing project variable/secret values will fail early in workflow validation.
+- If deployment succeeds but routes are broken, validate base paths and custom domain config.
+- Use the uploaded `staging-site-artifact` from failed workflow runs for path/content inspection.

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,7 +1,11 @@
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
+const defaultProductionBasePath = "/gametau/";
+const siteBasePath = process.env.SITE_BASE_PATH
+  ?? (process.env.NODE_ENV === "production" ? defaultProductionBasePath : "/");
+
 export default defineConfig({
-  base: process.env.NODE_ENV === "production" ? "/gametau/" : "/",
+  base: siteBasePath,
   plugins: [tailwindcss()],
 });


### PR DESCRIPTION
## Summary
- enable CI on both `master` and `development` to support an integration branch flow
- add `.github/workflows/staging-cloudflare.yml` to build and deploy `_site` to Cloudflare Pages from `development`
- parameterize `site/vite.config.ts` via `SITE_BASE_PATH` and document branch promotion/staging requirements in README, CONTRIBUTING, and release gates

## Test plan
- [x] `bun run lint`
- [x] `cd site && bunx vite build` (default base)
- [x] `cd site && SITE_BASE_PATH=/ bunx vite build` (staging base)
- [x] `cd examples/counter && bun run build:web`

Made with [Cursor](https://cursor.com)