### PR TITLE
docs(electrobun): publish example + platform validation matrix

### DIFF
--- a/docs/ELECTROBUN-EXPERIMENTAL.md
+++ b/docs/ELECTROBUN-EXPERIMENTAL.md
@@ -11,15 +11,15 @@ For the integration decision record, see `docs/ELECTROBUN-INTEGRATION-DECISION.m
 ## Stable vs Experimental Boundaries
 
 | Surface | Status | Notes |
-|---------|--------|-------|
+| --- | --- | --- |
 | Core invoke/convertFileSrc | Experimental | Provider registry delegates correctly |
 | Window adapter | Experimental | Full WindowAdapter interface wired |
 | Event adapter | Experimental | listen/emit delegation functional |
 | Filesystem adapter | Experimental | Full FsAdapter interface wired |
 | Dialog adapter | Experimental | Full DialogAdapter interface wired |
-| Example: counter | Not yet validated | Pending platform matrix (#84) |
-| Example: pong | Not yet validated | Pending platform matrix (#84) |
-| Example: battlestation | Not yet validated | Pending platform matrix (#84) |
+| Example: counter | Partially validated | Dedicated `electrobun-counter` path validated in CI; core `counter` example still lacks Electrobun scripts |
+| Example: pong | Blocked | No Electrobun run/build scripts in `examples/pong` |
+| Example: battlestation | Blocked | No Electrobun run/build scripts; native-window renderer caveat remains |
 
 ## Architecture
 
@@ -29,7 +29,7 @@ How Electrobun integrates with webtau:
 - **Module-level adapters** (`setWindowAdapter`, `setEventAdapter`, `setFsAdapter`, `setDialogAdapter`) for domain APIs — each adapter implements the same interface as the Tauri/web shim counterparts.
 - **`bootstrapElectrobun()`** convenience function — registers the provider and all adapters in a single call for quick setup.
 
-```
+```text
 ┌─────────────────────────────────────────┐
 │  Frontend: invoke("command", args)      │
 └──────────────┬──────────────────────────┘
@@ -66,17 +66,45 @@ bun run dev:electrobun
 ## Known Limitations
 
 - No `create-gametau --runtime electrobun` option yet (#75)
-- Platform matrix not yet validated (#84)
-- Dogfood automation pending (#85)
+- Core examples (`counter`, `pong`, `battlestation`) are not yet wired with Electrobun run/build scripts
+- Battlestation native-window renderer parity remains open (see integration decision doc)
 - Experimental flows may change across alpha releases
 - For production workloads today, prefer the stable Tauri desktop path
 
+## Example + Platform Matrix (#84)
+
+Status legend: `pass` means evidence-backed execution for that target, `blocked` means the target is not executable yet.
+
+| Example | Linux | macOS | Windows | Blocker summary | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| Counter (Electrobun path) | pass | pass | pass | `examples/counter` is not yet Electrobun-wired; validation currently runs through `examples/electrobun-counter` | [Dogfood run (all OS)](https://github.com/devallibus/gametau/actions/runs/22529340436), [Dogfood macOS job](https://github.com/devallibus/gametau/actions/runs/22529340436/job/65266319097), [Dogfood Windows job](https://github.com/devallibus/gametau/actions/runs/22529340436/job/65266319101), [Dogfood Linux job](https://github.com/devallibus/gametau/actions/runs/22529340436/job/65266319103), [CI Electrobun Counter Smoke (build:web + build:electrobun on Linux)](https://github.com/devallibus/gametau/actions/runs/22529278437/job/65266163923) |
+| Pong | blocked | blocked | blocked | No `dev:electrobun` or `build:electrobun` scripts in [`examples/pong/package.json`](../examples/pong/package.json) | [Pong package scripts](../examples/pong/package.json), [Rust WASM codegen check includes pong commands](https://github.com/devallibus/gametau/actions/runs/22529278437/job/65266163935) |
+| Battlestation | blocked | blocked | blocked | No Electrobun scripts in [`examples/battlestation/package.json`](../examples/battlestation/package.json); native-window renderer caveat still applies | [Battlestation package scripts](../examples/battlestation/package.json), [CI battlestation web smoke](https://github.com/devallibus/gametau/actions/runs/22529278437/job/65266163914), [Integration decision caveat](./ELECTROBUN-INTEGRATION-DECISION.md#2-threejs-render-boot-in-non-dom-runtime) |
+
+### Repro Notes For Blocked Rows
+
+From repo root:
+
+```bash
+bun run --cwd examples/counter build:electrobun
+bun run --cwd examples/pong build:electrobun
+bun run --cwd examples/battlestation build:electrobun
+# => error: Script not found "build:electrobun"
+```
+
+### Blocking Gaps (Severity + Owner)
+
+| Gap | Severity | Owner | Tracking |
+| --- | --- | --- | --- |
+| Core examples missing Electrobun scripts (`counter`, `pong`, `battlestation`) | P1 | @devallibus | #84 |
+| Scaffolder runtime flag remains deferred (`create-gametau --runtime electrobun`) | P1 | @devallibus | #75 |
+| Battlestation native-window renderer parity | P2 | @devallibus | [Integration decision](./ELECTROBUN-INTEGRATION-DECISION.md#2-threejs-render-boot-in-non-dom-runtime) |
+
 ## Evidence & CI
 
-<!-- Placeholders — to be filled as evidence becomes available -->
-- [ ] Dogfood workflow: (link pending, see #85)
-- [ ] Platform matrix: (link pending, see #84)
-- [ ] Contract test results: PR #87
+- [Dogfood workflow run (manual)](https://github.com/devallibus/gametau/actions/runs/22529340436)
+- [Latest master CI run](https://github.com/devallibus/gametau/actions/runs/22529278437)
+- [Contract and adapter delivery: PR #91](https://github.com/devallibus/gametau/pull/91)
 
 ## Related Issues
 


### PR DESCRIPTION
## Summary
- Replace the Electrobun example placeholders in `docs/ELECTROBUN-EXPERIMENTAL.md` with an evidence-backed `counter/pong/battlestation` matrix across Linux/macOS/Windows
- Document blocker severity + owner references and add reproducible commands showing why `pong` and `battlestation` are currently blocked for Electrobun validation
- Link fresh validation evidence from the manual Electrobun Dogfood run and latest green master CI run

## Test Plan
- [x] Trigger and verify manual dogfood run succeeded on all matrix OS legs: https://github.com/devallibus/gametau/actions/runs/22529340436
- [x] Verify latest master CI includes successful Electrobun counter smoke and related checks: https://github.com/devallibus/gametau/actions/runs/22529278437
- [x] Reproduce blocked status for core examples:
  - `bun run --cwd examples/counter build:electrobun`
  - `bun run --cwd examples/pong build:electrobun`
  - `bun run --cwd examples/battlestation build:electrobun`
  - each returns `Script not found build:electrobun`

## Tracking
- Closes #84
- Updates #78

Made with [Cursor](https://cursor.com)