### PR TITLE
docs: rewrite all public documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,300 +10,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.5.2] - 2026-03-01
 
 ### Added
-- Reusable Node ESM consumer smoke script (`scripts/smoke-webtau-esm-consumer.mjs`) to validate `webtau` importability from packed tarballs in clean environments.
+- Node ESM consumer smoke script (`scripts/smoke-webtau-esm-consumer.mjs`) to validate `webtau` importability from packed tarballs in clean environments.
 - Package-level smoke hook in `webtau`: `npm run smoke:esm-consumer`.
 
 ### Changed
-- CI `publish-preflight` and tag-time publish flow now run Node ESM consumer smoke before npm pack/publish steps.
-- Release gate docs now include explicit Node ESM consumer smoke as a release reliability requirement.
-- Workspace, crate, npm package, and template dependency versions moved to `0.5.2`.
-
-### Release Evidence
-- Publish workflow (`v0.5.2`) Green: [actions run](https://github.com/devallibus/gametau/actions/runs/22551613028)
-- Release commit: [`ee5ac65`](https://github.com/devallibus/gametau/commit/ee5ac65)
-- Release notes: [v0.5.2](https://github.com/devallibus/gametau/releases/tag/v0.5.2)
+- CI publish preflight and tag-time publish flow now run Node ESM consumer smoke before npm pack/publish steps.
 
 ## [0.5.1] - 2026-03-01
 
 ### Fixed
-- Internal ESM relative imports in `webtau` now use explicit `.js` specifiers, fixing Node consumer imports that failed with `ERR_MODULE_NOT_FOUND` in `0.5.0` (`import("webtau")` path). See [#109](https://github.com/devallibus/gametau/issues/109).
-
-### Changed
-- Workspace, crate, npm package, and template dependency versions moved to `0.5.1`.
-
-### Release Evidence
-- Publish workflow (`v0.5.1`) Green: [actions run](https://github.com/devallibus/gametau/actions/runs/22550637914)
-- Fix commit: [`d12eb55`](https://github.com/devallibus/gametau/commit/d12eb55)
-- Incident closure note: [issue comment](https://github.com/devallibus/gametau/issues/109#issuecomment-3980839013)
+- Internal ESM relative imports in `webtau` now use explicit `.js` specifiers, fixing `ERR_MODULE_NOT_FOUND` when consuming `webtau` from Node in `0.5.0`. See [#109](https://github.com/devallibus/gametau/issues/109).
 
 ## [0.5.0] - 2026-03-01
 
 ### Added
-- `webtau/task` lifecycle surface (`startTask`, `pollTask`, `cancelTask`, progress helpers) with deterministic state transition tests.
-- `webtau/adapters/tauri` adapter bootstrap surface (`bootstrapTauri`, `createTauriCoreProvider`, `createTauriEventAdapter`) for explicit desktop parity wiring.
-- Structured diagnostics envelope support in `webtau` (`WebtauError` with `code`, `runtime`, `command`, `message`, `hint`) plus non-panicking Rust/WASM bridge behavior.
+- `webtau/task` lifecycle surface: `startTask`, `pollTask`, `cancelTask`, and progress helpers for non-blocking long-running operations.
+- `webtau/adapters/tauri` adapter bootstrap: `bootstrapTauri()`, `createTauriCoreProvider()`, `createTauriEventAdapter()` for explicit Tauri event and invoke wiring.
+- Structured diagnostics envelope (`WebtauError` with `code`, `runtime`, `command`, `message`, `hint`) throughout the runtime bridge and WASM command wrappers.
+- Runtime provider contracts in `webtau/provider`: `CoreProvider`, `WindowAdapter`, `EventAdapter`, `FsAdapter`, `DialogAdapter`.
+- Provider registry APIs in `webtau/core`: `registerProvider`, `getProvider`, `resetProvider` with lazy Tauri auto-registration.
+- Adapter override hooks in `webtau/window`, `webtau/event`, `webtau/fs`, and `webtau/dialog`.
+- Experimental Electrobun runtime as an opt-in trial path (install with `webtau@alpha`; not the default scaffold target). See `examples/electrobun-counter` and [active milestones](https://github.com/devallibus/gametau/milestones).
 
 ### Changed
-- `create-gametau` base scaffold now wires `bootstrapTauri()` in desktop mode and ships task lifecycle backend seams in `src/services/backend.ts`.
-- Release/readiness docs now reference only public tracked artifacts for gate evidence and integration validation.
-- API docs generation now includes all public `webtau` entrypoints from the export map, including `task`, `provider`, and `adapters/*`.
-- Workspace, crate, npm package, and template dependency versions moved to `0.5.0`.
-- Stale milestone/issue tracking links in READMEs replaced with durable `/milestones` and `/issues` URLs.
-- `webtau/path` docs corrected: `delimiter` shipped in 0.4.0, only `resolveResource` remains unimplemented.
-
-### Version Coherence
-- `webtau` npm package jumps from `0.4.0` → `0.5.0` (aligning with `webtau-vite` and `create-gametau` on a stable line).
-- Template dependency pins for `three` and `pixi` jump from `^0.4.0` → `^0.5.0` to match.
-- Template `wasm/Cargo.toml` pin jumps from `0.4.0` → `0.5.0` to match.
-
-## [0.5.0-alpha.2] - 2026-02-28
-
-### Added
-- Dedicated `Electrobun Counter Smoke` CI job in `.github/workflows/ci.yml` that validates `examples/electrobun-counter` with both `build:web` and `build:electrobun`.
-- Failure artifact upload for Electrobun smoke outputs (`dist` and `build`) to speed up CI triage.
-
-### Changed
-- Workspace, crate, npm package, and template dependency versions moved to `0.5.0-alpha.2`.
-
-## [0.5.0-alpha.1] - 2026-02-28
-
-### Added
-- Runtime provider contracts in `webtau/provider` (`CoreProvider`, `WindowAdapter`, `EventAdapter`, `FsAdapter`, `DialogAdapter`)
-- Provider registry APIs in `webtau/core` (`registerProvider`, `getProvider`, `resetProvider`) with lazy Tauri provider self-registration
-- Adapter override hooks in `webtau/window`, `webtau/event`, `webtau/fs`, and `webtau/dialog`
-- Dedicated lazy Tauri auto-registration test coverage in `webtau/src/core.test.ts`
-- Experimental trial status tracked in [milestone v0.5.0 Complex Game Readiness](https://github.com/devallibus/gametau/milestone/10)
-- Isolated `examples/electrobun-counter` trial path with provider-based Electrobun bridge wiring
-
-### Changed
-- Runtime support messaging now explicitly distinguishes Stable (Web + Tauri) vs Experimental (Electrobun) in `README.md` and `packages/create-gametau/README.md`, with rollout tracked in [milestone v0.5.0 Complex Game Readiness](https://github.com/devallibus/gametau/milestone/10)
-- Workspace, crate, npm package, and template dependency versions moved to `0.5.0-alpha.1`
-
-### Experimental
-- Electrobun support remains opt-in and is distributed on the `alpha` line so `latest` stable users are unaffected.
-- Install alpha packages explicitly for trials:
-  - `npm install webtau@alpha webtau-vite@alpha create-gametau@alpha`
+- `create-gametau` base scaffold now wires `bootstrapTauri()` in desktop mode and ships task lifecycle seams in `src/services/backend.ts`.
+- API docs generation now covers all public `webtau` entrypoints including `task`, `provider`, and `adapters/*`.
+- `webtau/path` docs corrected: `delimiter` shipped in `0.4.0`; only `resolveResource` remains unimplemented.
 
 ## [0.4.0] - 2026-02-27
 
 ### Added
-- `convertFileSrc()` web shim in `webtau/core` for asset URL passthrough
-- `delimiter()`, `cacheDir()`, `configDir()`, `dataDir()`, `localDataDir()` web shims in `webtau/path`
-- `getIdentifier()` / `setAppIdentifier()` web shim in `webtau/app`
-- `copyFile()` and `rename()` virtual filesystem operations in `webtau/fs`
-- Workspace lint baseline with Biome plus CI lint enforcement
-- Expanded contract and edge-case test coverage across `webtau`, `webtau-vite`, and `webtau-macros`
-- Battlestation scenario smoke coverage in CI for gameplay success/failure assertions
-
-### Changed
-- Workspace, crate, npm package, and template dependency versions bumped to `0.4.0`
-- Generated artifact hygiene policy now enforced for local logs and Tauri schema outputs
-- Battlestation A130 design/showcase docs aligned with shipped command contract and combat semantics
+- `convertFileSrc()` web shim in `webtau/core` for asset URL passthrough.
+- `delimiter()`, `cacheDir()`, `configDir()`, `dataDir()`, `localDataDir()` web shims in `webtau/path`.
+- `getIdentifier()` / `setAppIdentifier()` web shim in `webtau/app`.
+- `copyFile()` and `rename()` virtual filesystem operations in `webtau/fs`.
+- Workspace lint baseline with Biome plus CI enforcement.
+- Battlestation scenario smoke coverage in CI.
 
 ### Fixed
-- API docs and release evidence artifact uploads now validate outputs and include hidden directories, preventing false-green publish runs
+- API docs artifact uploads now validate outputs and include hidden directories, preventing false-green publish runs.
 
 ## [0.3.1] - 2026-02-27
 
 ### Added
-- Site stack now includes Tailwind CSS v4 with Vite pipeline wiring
-- Battlestation radar renderer migrated from Canvas2D to Three.js with phase-2 visual polish
+- Battlestation radar renderer migrated from Canvas2D to Three.js with improved visual polish.
 
 ### Changed
-- Battlestation now uses responsive layout and DPR-aware canvas sizing for sharper rendering across viewport sizes
-- Workspace, crate, npm package, and template dependency versions bumped to `0.3.1`
+- Battlestation now uses responsive layout and DPR-aware canvas sizing for sharper rendering across viewport sizes.
 
 ### Fixed
-- `webtau-vite` now supports graceful fallback: when `wasm-pack` is unavailable and valid prebuilt artifacts exist, web builds/dev startup reuse them instead of hard-failing
-- `webtau-vite` fallback validation is stricter (paired `*_bg.wasm` + loader `.js` output) and fails fast when reusable artifacts are missing or incomplete
-- `webtau-vite` dev Rust watch rebuilds now clearly disable in fallback mode; `wasm-pack` remains required for fresh Rust/WASM builds and rebuild loops
+- `webtau-vite` now falls back gracefully when `wasm-pack` is unavailable but valid prebuilt artifacts exist in `wasmOutDir`, allowing web builds and dev startup to continue without a fresh compile.
+- Fallback validation is stricter: requires a paired `*_bg.wasm` and loader `.js`; fails fast when reusable artifacts are missing or incomplete.
+- Rust watch rebuilds are clearly disabled in fallback mode; `wasm-pack` remains required for fresh WASM builds and the hot-reload loop.
 
 ## [0.3.0] - 2026-02-27
 
 ### Added
-- Battlestation flagship showcase example (`examples/battlestation`) covering the full module story (`input`, `audio`, `assets`, `fs/path`, `event`, `app`) across web + desktop
-- Battlestation design/reuse rollout tracked in [roadmap issue #6](https://github.com/devallibus/gametau/issues/6)
-- Canonical stable release gate artifact in `.github/release/RELEASE-GATE-CHECKLIST.md` plus publish-time `Release Evidence Bundle` workflow artifact
-
-### Changed
-- Workspace, crate, npm package, and template dependency versions moved from prerelease to stable `0.3.0`
-- `create-gametau` templates now ship a production-oriented service layer (`settings`, `session`, `comms`, shared contracts) as default extension seams
-- CI wasm codegen checks now include `examples/battlestation`
-- README/Getting Started examples list now positions battlestation as flagship showcase
-
-### Stabilized
-- `app/path` parity shims, parity matrix docs, and release evidence discipline from the `0.3.0-alpha.2` line are now part of stable `0.3.0`
-
-## [0.3.0-alpha.2] - 2026-02-27
-
-### Added
-- Runtime parity shims for `@tauri-apps/api/app` and `@tauri-apps/api/path` (`webtau/app`, `webtau/path`)
-- `webtau-vite` alias coverage for `@tauri-apps/api/app` and `@tauri-apps/api/path`
-- Function-level parity rollout tracked in [roadmap issue #6](https://github.com/devallibus/gametau/issues/6)
-
-### Fixed
-- Prerelease version alignment so tag-triggered publish uses unreleased `0.3.0-alpha.2` manifests instead of previously published `0.2.1` versions
-- `webtau/app` setter signatures now accept `null` reset values without type-unsafe casts in tests
-
-### Changed
-- Workspace, crate, and npm package versions bumped to `0.3.0-alpha.2`
-- `create-gametau` template dependencies now target `webtau`/`webtau-vite` `^0.3.0-alpha.2` and Rust `webtau = "0.3.0-alpha.2"`
+- Battlestation flagship showcase (`examples/battlestation`) — full module coverage (`input`, `audio`, `assets`, `fs/path`, `event`, `app`) running across web and desktop.
+- `webtau/app` and `webtau/path` runtime parity shims, plus `webtau-vite` alias coverage for both.
+- `create-gametau` templates now include a production-oriented service layer (`settings`, `session`, `comms`, and shared contracts) as extension seams.
 
 ## [0.2.1] - 2026-02-26
 
 ### Added
-- New onboarding and operations docs: scaffold-to-playable tutorial, release incident response checklist, and automated API docs publication path
-- Web parity shims for `@tauri-apps/api` modules: `fs`, `dialog`, and `event`
-- Gameplay foundation modules in `webtau`: `input`, `audio`, and `assets`
-- Pong example integration path that exercises input, audio, and asset loading together
+- Web parity shims for `@tauri-apps/api` modules: `fs`, `dialog`, and `event`.
+- Gameplay foundation modules: `webtau/input`, `webtau/audio`, and `webtau/assets`.
+- Pong example exercising input, audio, and asset loading together.
 
 ### Fixed
-- PR-time scaffold smoke now rewrites scaffolded Rust `webtau` dependencies to the local workspace crate so CI can validate unreleased lines before crates.io publish
-
-### Changed
-- `create-gametau` templates now target `webtau`/`webtau-vite` `^0.2.0` and Rust `webtau = "0.2"` for scaffolded projects
-- README roadmap now reflects `0.2.x` as the current stable line
-- Release versions bumped to `0.2.1` for `webtau`, `webtau-vite`, `create-gametau`, `webtau`, and `webtau-macros`
+- PR-time scaffold smoke now rewrites scaffolded Rust `webtau` dependencies to the local workspace crate so CI validates unreleased lines before crates.io publish.
 
 ## [0.1.4] - 2026-02-26
 
 ### Fixed
-- Hyphenated scaffold names now generate valid Rust module identifiers in templates (e.g. `my-game` → `my_game`) for commands/app/wasm imports
-- Consumer smoke builds now work with the existing `smoke-game` scaffold target name
-
-### Changed
-- Scaffolder now applies Rust identifier normalization for `{{PROJECT_NAME}}_` template usages while preserving display/package names
-- Release versions bumped to `0.1.4` for `webtau`, `webtau-vite`, `create-gametau`, `webtau`, and `webtau-macros`
+- Hyphenated scaffold names now generate valid Rust module identifiers in templates (e.g. `my-game` → `my_game`).
 
 ## [0.1.3] - 2026-02-26
 
 ### Fixed
-- Scaffolded template Rust builds no longer fail on `wasm32-unknown-unknown` due to `getrandom` feature gating from `rand` defaults
-- Consumer smoke now progresses through scaffold/install/build for newly published `create-gametau` templates
-
-### Changed
-- Template `rand` dependency now disables default features and enables only `std` + `std_rng`
-- Release versions bumped to `0.1.3` for `webtau`, `webtau-vite`, `create-gametau`, `webtau`, and `webtau-macros`
+- Scaffolded template Rust builds no longer fail on `wasm32-unknown-unknown` due to `getrandom` feature gating.
+- Consumer smoke now completes scaffold, install, and build steps for newly published `create-gametau` templates.
 
 ## [0.1.2] - 2026-02-26
 
 ### Fixed
-- `create-gametau` now executes correctly when launched through npm-style `node_modules/.bin` shims (previously it could no-op and exit `0`)
-- Release verification now asserts CLI version output and fails if `create-gametau` does not actually execute
-- Consumer smoke scaffolding now verifies the scaffolded directory exists immediately after CLI invocation
-
-### Changed
-- Release versions bumped to `0.1.2` for `webtau`, `webtau-vite`, `create-gametau`, `webtau`, and `webtau-macros`
+- `create-gametau` now executes correctly when launched through `node_modules/.bin` shims (previously could silently exit `0`).
+- Release verification now asserts CLI version output and fails if `create-gametau` does not execute.
+- Consumer smoke now verifies the scaffolded directory exists immediately after CLI invocation.
 
 ## [0.1.1] - 2026-02-26
 
 ### Added
-- CI now enforces MSRV `1.77` with a dedicated `MSRV (1.77)` workflow job
-- Publish workflow now verifies npm/crates.io artifacts after release before declaring success
-- Publish workflow now includes a registry consumer smoke test and manual `workflow_dispatch` verification path
-
-### Changed
-- `webtau` and `webtau-macros` now inherit `rust-version` from workspace metadata for published crate manifests
-- Release versions bumped to `0.1.1` for `webtau`, `webtau-vite`, `create-gametau`, `webtau`, and `webtau-macros`
+- CI now enforces MSRV `1.77` with a dedicated workflow job.
+- Publish workflow verifies npm and crates.io artifacts after release before declaring success.
+- Publish workflow includes a registry consumer smoke test and manual `workflow_dispatch` verification path.
 
 ## [0.1.0] - 2026-02-26
 
-First stable release. Deploy Tauri games to web + desktop from one codebase.
-
-### Highlights
-- **`webtau` npm package** — `invoke()` universal router with automatic Tauri/WASM detection, `isTauri()` runtime check, window shims, and DPI utilities
-- **`webtau-vite` npm package** — Vite plugin with wasm-pack automation, Rust file watching, `@tauri-apps/api` import aliasing, and optional wasm-opt
-- **`create-gametau` CLI** — project scaffolder with Three.js, PixiJS, and vanilla Canvas2D templates
-- **`webtau` Rust crate** — `#[webtau::command]` proc macro (generates `#[tauri::command]` + `#[wasm_bindgen]` from one function) and `wasm_state!` macro for WASM thread-local state
-- **`webtau-macros` Rust crate** — proc macro internals for `#[webtau::command]`
-
-### Published Artifacts
-- npm: `webtau`, `webtau-vite`, `create-gametau` (all `0.1.0`)
-- crates.io: `webtau`, `webtau-macros` (both `0.1.0`)
-
-### Changed
-- All template dependency pins switched from prerelease to stable (`^0.1.0` for npm, `0.1` for Cargo)
-
-## [0.1.0-alpha.5] - 2026-02-26
-
-### Fixed
-- `create-gametau` now ships a dotless `gitignore` file so `npm pack` includes it
-- Packaged CLI regressions guarded with smoke tests
-- `dist/` test guard skips tests when dist is not built
+First stable release. Deploy Tauri games to web and desktop from one codebase.
 
 ### Added
-- Hardened packaged CLI smoke checks in CI
-- README logo
-
-### Removed
-- Unused `minimal-game` test fixture
-
-### Changed
-- Release versions bumped to `0.1.0-alpha.5` across all artifacts
-
-## [0.1.0-alpha.4] - 2026-02-26
-
-### Fixed
-- Retry guard quoting in `webtau` crate publish workflow
-- Already-published crates now treated as success instead of failing the pipeline
-- Retry logic for `webtau` publish on crates.io index propagation lag
-
-### Changed
-- Release versions bumped to `0.1.0-alpha.4` across all artifacts
-
-## [0.1.0-alpha.3] - 2026-02-26
-
-### Added
-- CI publish preflight job with Rust/npm dry-run checks (`cargo publish --dry-run`, `npm pack --dry-run`)
-- Contributor guidance for prerelease template pinning and stable-switch policy
-
-### Changed
-- Release versions bumped to `0.1.0-alpha.3` across workspace crates, npm packages, and scaffolder templates
-- Smoke CI step names were clarified for faster diagnostics
-- Web crate preflight logic now handles prerelease dependency checks safely during CI
-
-### Release Proof
-- Tag: `v0.1.0-alpha.3`
-- Publish workflow run: https://github.com/devallibus/gametau/actions/runs/22446985795
-- Published npm packages:
-  - `webtau@0.1.0-alpha.3`
-  - `webtau-vite@0.1.0-alpha.3`
-  - `create-gametau@0.1.0-alpha.3`
-- Published crates:
-  - `webtau-macros 0.1.0-alpha.3`
-  - `webtau 0.1.0-alpha.3`
-- Note: workflow publish partially failed due registry-side trusted publisher auth mismatch for `webtau-vite` and `webtau-macros`; missing artifacts were published manually and verified.
-
-## [0.1.0-alpha.2] - 2026-02-26
-
-### Added
-- `#[webtau::command]` v2 proc macro — generates both `#[tauri::command]` and `#[wasm_bindgen]` wrappers from a single function definition
-- Scaffolder now generates v2 4-crate structure (core, commands, app, wasm)
-
-### Fixed
-- Landing page template flag corrected from `threejs` to `three` to match CLI behavior
-- Contributor docs updated to reflect v2 architecture and command flow
-
-### Changed
-- Rust publish workflow now handles `webtau-macros` before `webtau` for correct dependency order
-- Rust publish workflow now polls crates.io index propagation before publishing dependent crates
-- `webtau-macros` crate is now publishable to crates.io
-- npm publish workflow now uses `--tag alpha` for prerelease releases
-- CI now includes scaffold and web build smoke checks on pull requests
-- All package versions aligned to `0.1.0-alpha.2` (npm + crates.io)
-- Scaffolder templates now pin Rust `webtau` dependency to `0.1.0-alpha.2`
-- Added `.claude/`, `.cursor/plans/`, `.instance/` to `.gitignore` for cleaner local status
-
-## [0.1.0-alpha.1] - 2025-06-14
-
-### Added
-- `webtau` npm package: `invoke()` universal router with automatic Tauri/WASM detection, `isTauri()` runtime check, WASM module deduplication and retry logic
-- `webtau/window`: `WebWindow` shim for `@tauri-apps/api/window` (fullscreen, size, title, monitor, scale factor, decorations, center)
-- `webtau/dpi`: `LogicalSize`, `PhysicalSize`, `LogicalPosition`, `PhysicalPosition` with conversion methods
-- `webtau-vite` npm package: Vite plugin with wasm-pack automation, Rust file watching, `@tauri-apps/api` import aliasing, optional wasm-opt
-- `create-gametau` npm package: project scaffolder CLI with Three.js, PixiJS, and vanilla Canvas2D templates
-- `webtau` Rust crate: `wasm_state!` macro for WASM thread-local state management (`set_state`, `with_state`, `with_state_mut`)
-- `examples/counter`: end-to-end working demo (browser WASM + Tauri desktop)
-- `examples/pong`: two-player Pong with Rust physics, PixiJS rendering, and keyboard input
-- GitHub CI: Rust (clippy + tests) and TypeScript (bun test + tsc) pipelines
-- Apache-2.0 license with optional commercial license for high-revenue games
+- **`webtau` npm package** — `invoke()` universal router with automatic Tauri/WASM detection, `isTauri()` runtime check, window shims, and DPI utilities.
+- **`webtau-vite` npm package** — Vite plugin with wasm-pack automation, Rust file watching, `@tauri-apps/api` import aliasing, and optional wasm-opt.
+- **`create-gametau` CLI** — project scaffolder with Three.js, PixiJS, and vanilla Canvas2D templates; generates a ready-to-run 4-crate Rust workspace (`core`, `commands`, `app`, `wasm`).
+- **`webtau` Rust crate** — `#[webtau::command]` proc macro generating both `#[tauri::command]` and `#[wasm_bindgen]` wrappers from a single function, and `wasm_state!` macro for WASM thread-local state.
+- **`webtau-macros` Rust crate** — proc macro internals for `#[webtau::command]`.
+- `examples/counter` — minimal end-to-end demo (browser WASM + Tauri desktop).
+- `examples/pong` — two-player Pong with Rust physics, PixiJS rendering, and keyboard input.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,23 @@
-# Contributing to Gametau
+# Contributing to gametau
 
-Thanks for your interest in contributing! This guide will get you oriented quickly.
+Thanks for your interest in contributing!
 
-## Architecture Primer
+## How the codebase is organized
 
-Gametau follows a 4-crate model (v2) that enforces clean separation between game logic, shared command definitions, and platform bindings.
+gametau uses a 4-crate model that keeps game logic, command definitions, and platform bindings in separate layers.
 
 ```
 core/       Pure game logic. No framework deps, no Tauri, no WASM.
 commands/   Shared command definitions. #[webtau::command] generates both targets.
 app/        Tauri desktop shell. Imports commands, registers with generate_handler!.
-wasm/       WASM entry point. Links commands crate (exports auto-wired).
+wasm/       WASM entry point. Links the commands crate (exports auto-wired).
 ```
 
-The **dual-target constraint** is the key design rule: every command must work through both Tauri IPC (native desktop) and direct WASM call (browser). The `#[webtau::command]` proc macro generates both `#[tauri::command]` and `#[wasm_bindgen]` wrappers from a single function definition, so you write each command once in `commands/`.
+**The dual-target constraint** is the key design rule: every command must work through both Tauri IPC (native desktop) and direct WASM call (browser). The `#[webtau::command]` proc macro generates both `#[tauri::command]` and `#[wasm_bindgen]` wrappers from a single function, so you write each command once in `commands/`.
 
 If your change touches the command surface, make sure it compiles for both native and `wasm32-unknown-unknown` targets.
 
-## Minimum Supported Rust Version (MSRV)
-
-The workspace MSRV is **1.77**. CI enforces this with a dedicated check job. Run `cargo +1.77 check --workspace` before bumping any dependency to verify MSRV compatibility.
-
-## Dev Setup
+## Dev setup
 
 ### Prerequisites
 
@@ -29,7 +25,7 @@ The workspace MSRV is **1.77**. CI enforces this with a dedicated check job. Run
   ```sh
   rustup target add wasm32-unknown-unknown
   ```
-- **wasm-pack**
+- **wasm-pack** — required for WASM builds and the dev hot-reload loop
 - **Bun** (recommended) or Node 18+
 - **Tauri CLI** (only needed for desktop builds)
 
@@ -52,83 +48,90 @@ cargo test --workspace
 cargo clippy --workspace -- -D warnings
 ```
 
-### Run the Example
+### Run an example
 
 ```sh
 cd examples/counter && bun run dev
 ```
 
-## What We Welcome
+## What we welcome
 
-- Bug fixes
-- Window/DPI shim improvements
-- New scaffolder templates
-- Documentation improvements
-- Test coverage expansion
+Good places to start:
 
-## What Needs Discussion First
+- **Bug fixes** — especially in the shims (`webtau/fs`, `webtau/dialog`, `webtau/window`) where browser API coverage is still expanding
+- **New shim methods** — fill gaps in `webtau/path`, `webtau/app`, `webtau/window` to improve parity with Tauri's API surface
+- **New scaffolder templates** — additional renderer or framework templates alongside Three.js, PixiJS, and Canvas2D
+- **Test coverage** — unit tests for edge cases in `invoke()`, `wasm_state!`, or the shims
+- **Documentation improvements** — clearer examples, fixed typos, better explanations of tricky concepts
 
-Please open an issue before submitting a PR for any of the following:
+## What needs discussion first
+
+Please open an issue before submitting a PR for:
 
 - Breaking API changes to `invoke()` or `configure()`
-- New core dependencies
+- New core dependencies (npm or Cargo)
 - Changes to the `#[webtau::command]` proc macro in `webtau-macros`
 
-## PR Process
+## Making a PR
 
-1. **Open an issue first** for non-trivial changes.
-2. **All CI must pass** — Rust clippy + tests, TypeScript tests + type checks.
-3. **Use conventional commits**: `feat:`, `fix:`, `chore:`, `docs:`, etc.
-4. **Keep PRs focused** — one concern per PR.
+1. Open an issue first for non-trivial changes.
+2. All CI must pass — Rust clippy + tests, TypeScript tests + type checks.
+3. Use conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, etc.
+4. Keep PRs focused — one concern per PR.
 
-## Branch and deployment flow
+## Minimum Supported Rust Version (MSRV)
 
-- `feature/*` branches target `development`.
-- `development` is staging and deploys to Worker `gametau-dev` (`dev.gametau.devallibus.com`).
-- `master` is production and deploys to Worker `gametau-prod` (`gametau.devallibus.com`).
-- Promote from `development` to `master` only after staging smoke checks pass.
+The workspace MSRV is **1.77**. CI enforces this with a dedicated check job. Run `cargo +1.77 check --workspace` before bumping any dependency to verify MSRV compatibility.
 
-Workers deploy workflows require repository secrets:
+## Environments and deployment
 
-- `CLOUDFLARE_ACCOUNT_ID`
-- `CLOUDFLARE_API_TOKEN`
+The repo uses two long-lived branches:
 
-## CI Publish Preflight Expectations
+| Branch | Role | URL |
+|---|---|---|
+| `master` | Production | `gametau.devallibus.com` (Worker: `gametau-prod`) |
+| `development` | Staging | `dev.gametau.devallibus.com` (Worker: `gametau-dev`) |
+
+Feature branches target `development`. Promote from `development` to `master` only after staging smoke checks pass.
+
+The site and API docs are deployed via Cloudflare Workers. Deploy workflows:
+
+- `.github/workflows/deploy-workers-prod.yml`
+- `.github/workflows/deploy-workers-staging.yml`
+
+Required repository secrets for deployment: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`.
+
+## Release process
+
+### CI publish preflight
 
 The CI workflow includes a **Publish Preflight** job to catch release regressions before tags are pushed.
 
-- Rust checks:
-  - `cargo publish -p webtau-macros --dry-run`
-  - `cargo publish -p webtau --dry-run`
-  - Expected signal: packaging + verification logs and exit code `0`.
-- npm checks:
-  - `npm pack --dry-run` in:
-    - `packages/webtau`
-    - `packages/webtau-vite`
-    - `packages/create-gametau`
-  - Expected signal: tarball metadata/file-list output and exit code `0`.
+Rust checks:
+- `cargo publish -p webtau-macros --dry-run`
+- `cargo publish -p webtau --dry-run`
 
-Any non-zero exit or missing package/tarball metadata should be treated as a release blocker.
+npm checks (`npm pack --dry-run` in each):
+- `packages/webtau`
+- `packages/webtau-vite`
+- `packages/create-gametau`
 
-## Release Incident Response
+Any non-zero exit or missing tarball metadata is a release blocker.
 
-If a tag-triggered release fails (or partially publishes), follow the canonical checklist:
+### Tagging and publishing
 
-- `.github/release/RELEASE-INCIDENT-RESPONSE.md`
+Full release gate requirements and sign-off checklist: [`.github/release/RELEASE-GATE-CHECKLIST.md`](.github/release/RELEASE-GATE-CHECKLIST.md).
 
-## Template Dependency Versioning Policy
+If a release fails or partially publishes, follow the incident runbook: [`.github/release/RELEASE-INCIDENT-RESPONSE.md`](.github/release/RELEASE-INCIDENT-RESPONSE.md).
 
-Templates should target the current stable line by default.
+## Template dependency versioning
 
-- JS template references: `packages/create-gametau/templates/base/package.json`
+Templates target the current stable line by default.
+
+- JS template reference: `packages/create-gametau/templates/base/package.json`
 - Rust template reference: `packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml`
 
-During prerelease (`alpha`, `beta`, `rc`) development for an upcoming release:
-
-- Pin template dependencies to the in-flight prerelease line so smoke coverage is deterministic.
-- Before cutting the corresponding stable tag, switch template dependency ranges back to the stable syntax for that release line.
-
-Track versioning policy changes in the active release milestone/issues rather than legacy release follow-ups.
+During prerelease development for an upcoming release, pin template dependencies to the in-flight prerelease line for deterministic smoke coverage. Switch back to stable syntax before cutting the corresponding stable tag.
 
 ## CLA
 

--- a/INTEGRATION-PROXY-VALIDATION.md
+++ b/INTEGRATION-PROXY-VALIDATION.md
@@ -1,44 +1,41 @@
-# Integration Proxy Validation Track
+# Integration Validation Runbook
 
-Use this runbook to validate `gametau` integration readiness using only public repository assets.
+Use this runbook to validate that gametau's core workflows function end-to-end using only public repository assets. Run it before a release or when onboarding a new integration.
 
-## Purpose
+## What this covers
 
-- Validate integration workflows end-to-end using only public repo assets.
-- Stress the same seams downstream games and apps will use (`commands.rs`, typed frontend wrappers, runtime bridge, persistence/eventing).
-- Produce an evidence bundle that release gates can consume.
+- Scaffold boot and project structure
+- Adding new commands and calling them from the frontend
+- Persistence, events, task lifecycle, and diagnostics
+- Installing and using published artifacts in a clean consumer environment
 
-## Scope Boundaries
+Validation is intentionally limited to gametau's own products (runtime bridge, templates, docs) using the public repo. App-specific code in downstream projects is out of scope.
 
-- Requirements are derived from public contract surfaces and shipped API behavior.
-- Validation target is `gametau` products: runtime bridge, templates, docs, and release process.
-- App-specific implementation details outside this repository are intentionally out of scope.
+## Validation assets
 
-## Validation Assets
-
-- Open showcase baseline: `examples/battlestation`
+- Showcase baseline: `examples/battlestation`
 - Fresh scaffold baseline: `bunx create-gametau integration-proxy`
-- Template seams under direct test:
+- Template seams under test:
   - `packages/create-gametau/templates/base/src/index.ts`
   - `packages/create-gametau/templates/base/src/services/backend.ts`
   - `packages/create-gametau/templates/base/src-tauri/commands/src/commands.rs`
 
-## Scenario Matrix
+## Scenario matrix
 
 | Scenario | Goal | Required evidence |
 | --- | --- | --- |
-| CPV-1: Scaffold boot | Fresh scaffold runs in web and desktop modes without architecture rewrites | Terminal logs/screenshots for `bun run dev` and `bun run dev:tauri` |
-| CPV-2: Command extension seam | Add one new typed command from Rust to frontend UI path | Patch/diff summary, command test output, UI invocation proof |
-| CPV-3: Persistence + eventing | Persist and reload state; emit/listen app event in both targets | Round-trip output logs and event callback verification |
-| CPV-4: Diagnostics quality | Trigger one known failure (for example missing command export) and verify error clarity | Captured error output + remediation steps applied |
-| CPV-5: Release-consumer smoke | Validate install/use from published artifacts path | Workflow links and smoke script output |
-| CPV-6: Long-running task lifecycle | Validate non-blocking `start/poll/cancel` behavior for heavy operations | Task status trace, cancellation proof, UI responsiveness capture |
-| CPV-7: Backend event parity | Validate ordered backend progress/state events and listener lifecycle | Ordered event log, multi-listener output, unlisten proof |
-| CPV-8: Structured diagnostics envelope | Validate error payload shape for invalid args/state-init/missing command paths | Error snapshot asserting `code/runtime/command/message/hint` fields |
+| CPV-1: Scaffold boot | A freshly scaffolded project starts in both web and Tauri modes without any changes to the generated structure | Startup logs and one screenshot per target |
+| CPV-2: Command extension | Add one typed command in Rust and call it from the TypeScript frontend — proving the seam works end-to-end | Diff, command test output, UI invocation screenshot |
+| CPV-3: Persistence + eventing | Write and reload a small state payload with `webtau/fs`; emit and receive an event with `webtau/event` — both in web and desktop | Round-trip logs, event callback output |
+| CPV-4: Diagnostics quality | Trigger a controlled failure (for example, call a missing command) and confirm the error output points clearly to a fix | Captured error output plus corrected re-run |
+| CPV-5: Release consumer smoke | Install and use gametau from published npm/crates.io artifacts in a clean environment | Workflow links and smoke script output |
+| CPV-6: Long-running task lifecycle | Use `startTask`/`pollTask`/`cancelTask` for a slow operation and verify the UI stays responsive throughout | Task status trace, cancellation proof, responsiveness capture |
+| CPV-7: Backend event parity | Emit ordered progress events from the backend and verify delivery order, multi-listener behavior, and clean unlisten | Ordered event log, multi-listener output, unlisten proof |
+| CPV-8: Structured diagnostics envelope | Trigger three failure modes (invalid args, missing command, uninitialized state) and assert the full error shape | Error snapshots asserting `code`, `runtime`, `command`, `message`, `hint` |
 
-## Step-by-Step Procedure
+## Step-by-step procedure
 
-### 1) Run scaffold baseline
+### 1. Run the scaffold baseline (CPV-1)
 
 ```bash
 bunx create-gametau integration-proxy
@@ -50,101 +47,84 @@ bun run dev:tauri
 
 Record startup logs and one screenshot per target.
 
-### 2) Validate command extension seam
+### 2. Extend with a new command (CPV-2)
 
-Add one command in scaffolded `src-tauri/commands/src/commands.rs`, add a typed wrapper in `src/services/backend.ts`, and call it from the UI.
+Add one command to `src-tauri/commands/src/commands.rs`, a typed wrapper to `src/services/backend.ts`, and call it from the UI.
 
-Expected outcome:
+Expected: the command compiles for both desktop and `wasm32`, and the frontend call resolves in both runtimes.
 
-- Command compiles for desktop + wasm.
-- Frontend call succeeds in both web and Tauri runtime.
+### 3. Validate persistence and eventing (CPV-3)
 
-### 3) Validate persistence and eventing
+Use `webtau/fs` and `webtau/path` to write and read a small profile payload. Use `webtau/event` to emit a test event and receive it in a listener.
 
-Use `webtau/fs` + `webtau/path` to write/read a small profile payload, and `webtau/event` to emit/listen a test event.
+Expected: data survives a round-trip without shape drift; the event callback fires in both web and Tauri.
 
-Expected outcome:
+### 4. Validate diagnostics (CPV-4)
 
-- Data round-trips without shape drift.
-- Event callback receives payload in both runtime targets.
+Call a command that does not exist. Confirm the error output includes a clear remediation (for example, a list of available exports or a `configure()` call pattern).
 
-### 4) Validate diagnostics path
+Expected: error is actionable; a corrected run succeeds without additional hidden setup.
 
-Introduce one controlled failure (for example call a non-existent command) and confirm the error points to a clear fix path.
+### 5. Validate published artifacts (CPV-5)
 
-Expected outcome:
+Install `webtau` and `create-gametau` from the published npm/crates.io artifacts in a clean directory (not the monorepo). Scaffold a project and confirm it builds.
 
-- Error includes actionable guidance.
-- A corrected run succeeds without additional hidden setup.
+Expected: published artifacts install and run; any issue is documented with a mitigation.
 
-### 5) Capture release-consumer smoke
+### 6. Validate task lifecycle (CPV-6)
 
-Run consumer smoke using published artifact expectations from release workflows. Capture URLs and logs in the evidence bundle.
+Start a synthetic slow command with `startTask`, poll with `pollTask`, and cancel with `cancelTask`. Assert:
 
-Expected outcome:
+- The UI render loop stays responsive while the task is running.
+- Progress increments monotonically.
+- Cancellation stops further state mutation when `startTask(..., { onCancel })` is wired to backend logic.
 
-- Published artifacts install and run in a clean consumer environment.
-- Any issue is documented with mitigation or fix-forward note.
+### 7. Validate backend event parity (CPV-7)
 
-### 6) Validate long-running task lifecycle
+Run a backend path that emits ordered progress events. Assert:
 
-Run one synthetic heavy command through `start/poll/cancel` and assert:
+- Events arrive in order.
+- Two independent listeners receive consistent payloads.
+- After `unlisten()`, no further callbacks fire.
 
-- UI/render loop remains responsive.
-- Progress moves monotonically.
-- Cancellation stops further state mutation (when `startTask(..., { onCancel })` is wired to backend cancellation).
+### 8. Validate diagnostics envelope shape (CPV-8)
 
-### 7) Validate backend event parity
+Trigger three controlled failures and assert each error payload contains `code`, `runtime`, `command`, `message`, and `hint`:
 
-Run one progress-emitting backend path and assert:
+| Failure | Expected `code` | Expected `hint` |
+|---|---|---|
+| Call a missing command | `UNKNOWN_COMMAND` | Lists available exports |
+| WASM module load failure | `LOAD_FAILED` | Contains the original error message |
+| `invoke()` before `configure()` | `NO_WASM_CONFIGURED` | Shows the correct `configure()` call pattern |
 
-- Event order is preserved.
-- Multiple listeners receive consistent payloads.
-- Unlisten prevents further callbacks.
+## Evidence bundle
 
-### 8) Validate structured diagnostics envelope
+For each validation run, record:
 
-Trigger controlled failures (invalid args, missing command, uninitialized state) and assert:
+1. Run metadata: date, branch, commit SHA, and who ran it.
+2. CPV-1..CPV-8 results: pass or fail, with notes on any failures.
+3. Links to logs, screenshots, or CI run output.
+4. Known gaps or friction encountered, with mitigations or follow-up issues.
 
-- No panic crash behavior.
-- Error payload contains `code`, `runtime`, `command`, `message`, and `hint`.
-- Docs remediation steps resolve each failure path.
+### CPV-6 artifacts
 
-## Evidence Bundle Template
+- `task.test.ts` output confirming all lifecycle tests pass.
+- Cancellation proof: `cancelTask()` transitions state to `"cancelled"`; subsequent `pollTask()` returns `{ state: "cancelled" }`.
+- Evidence that the render loop was not blocked during a simulated heavy task.
 
-For each proxy validation run, store:
+### CPV-7 artifacts
 
-1. Run metadata: date, branch, commit SHA, operator.
-2. Scenario results: CPV-1..CPV-8 pass/fail with notes.
-3. Logs and screenshots links.
-4. Known limits encountered and mitigations.
-5. Follow-up issue links for unresolved friction.
+- `tauri.test.ts` parity contract output (ordered delivery, multi-listener, unlisten precision).
+- `event.test.ts` DOM bridge parity output (same contract on web).
+- Multi-listener log showing both listeners received identical payloads.
+- Unlisten proof: listener count drops to zero; no further callbacks.
 
-### CPV-6 Evidence Artifacts (Long-Running Task Lifecycle)
+### CPV-8 artifacts
 
-- `task.test.ts` output confirming all 20 lifecycle tests pass.
-- Cancellation proof: `cancelTask()` transitions state to "cancelled" and subsequent `pollTask()` returns `{ state: "cancelled" }`.
-- UI responsiveness capture: render loop remains unblocked during a simulated heavy `startTask()` call.
+- `core.test.ts` `WebtauError` envelope shape test output (all passing).
+- Error snapshots for each of the three failure modes above, asserting all five envelope fields are present.
 
-### CPV-7 Evidence Artifacts (Backend Event Parity)
+## Pass criteria
 
-- `tauri.test.ts` parity contract output (ordered delivery, multi-listener, unlisten precision — all pass).
-- `event.test.ts` DOM bridge parity output (same contract on web path).
-- Multi-listener log showing both listeners receive identical payloads.
-- Unlisten proof: listener count drops to 0 after `unlisten()`, no further callbacks.
-
-### CPV-8 Evidence Artifacts (Structured Diagnostics Envelope)
-
-- `core.test.ts` WebtauError envelope shape test output (all pass).
-- Error snapshot asserting presence of `code`, `runtime`, `command`, `message`, `hint` for each of:
-  - Missing command: `code: "UNKNOWN_COMMAND"`, `hint` lists available exports.
-  - Load failure: `code: "LOAD_FAILED"`, `message` contains original error.
-  - No WASM configured: `code: "NO_WASM_CONFIGURED"`, `hint` points to `configure()`.
-
-## Pass Criteria
-
-- CPV-1..CPV-8 pass, or open failures have accepted mitigations and owners.
-- Required docs remain accurate after the run:
-  - `README.md`
-  - `.github/release/RELEASE-GATE-CHECKLIST.md`
-  - `.github/release/RELEASE-INCIDENT-RESPONSE.md`
+- CPV-1..CPV-8 pass, or any failures have documented mitigations and assigned owners.
+- These docs remain accurate after the run: `README.md`, `.github/release/RELEASE-GATE-CHECKLIST.md`, `.github/release/RELEASE-INCIDENT-RESPONSE.md`.

--- a/README.md
+++ b/README.md
@@ -10,33 +10,27 @@
 
 A toolkit for building games in Rust that run in the browser (WASM) and on desktop from one codebase.
 
-Stable desktop support is via [Tauri](https://v2.tauri.app/). Electrobun is available as an explicit experimental track for opt-in trials.
-
-> Repository note: `docs/` is intentionally local-only and is not published in remote history. Any `docs/...` path in this file assumes a local clone where that directory exists.
-
-You write your game logic once in a plain Rust crate. gametau gives you:
-
-- **A runtime bridge** (`webtau`) that lets your frontend call Rust functions identically on both platforms — Tauri IPC on desktop, direct WASM calls in the browser
-- **A Vite plugin** (`webtau-vite`) that compiles your Rust to WASM on save, watches for changes, and hot-reloads
-- **A scaffolder** (`create-gametau`) that generates a ready-to-run project with all of this wired up
-
-**[Play the Battlestation demo in your browser →](https://gametau.devallibus.com/battlestation/)** — Flagship tactical radar loop running as WASM in-browser from the same Rust command surface used on desktop.
-
-## Supported Runtimes
-
-**Stable (production default)**
-- **Web (WASM)**
-- **Desktop (Tauri)**
-
-**Experimental (opt-in)**
-- **Desktop (Electrobun)** — under evaluation, not the default scaffolder/runtime path
-- Trial and release track: see [active milestones](https://github.com/devallibus/gametau/milestones)
+**[Play the Battlestation demo in your browser →](https://gametau.devallibus.com/battlestation/)**
 
 ---
 
-## Quick Start
+## What is gametau?
 
-### New project
+Tauri is the right choice for the desktop side of a Rust game. But Tauri has no web target — `invoke()` routes through IPC that only exists inside the Tauri process. Without something to bridge that gap, your dev loop is locked to `tauri dev`, you can't share a playable build without shipping a native installer, and your simulation code can only ever run on desktop.
+
+gametau gives you the web build back without touching your game logic. You write Rust once; the toolkit compiles it to both a native desktop binary (via Tauri) and a WASM module (via wasm-pack), and routes your frontend's `invoke("command")` calls to whichever is available at runtime — automatically.
+
+Three packages work together:
+
+- **`webtau`** (npm + Rust crate) — the runtime bridge. Routes `invoke()` calls to Tauri IPC on desktop and to direct WASM calls in the browser. Includes shims for Tauri's filesystem, dialog, window, event, and path APIs so the same import paths work on both targets.
+- **`webtau-vite`** — the build plugin. Compiles your Rust to WASM on save, watches for changes, and hot-reloads your browser tab. Zero config for the standard project layout.
+- **`create-gametau`** — the scaffolder. Generates a ready-to-run project with the Rust workspace, Vite config, and TypeScript service layer already wired up.
+
+---
+
+## Getting Started
+
+### 1. Scaffold a new project
 
 ```bash
 bunx create-gametau my-game              # Three.js (default)
@@ -45,509 +39,27 @@ bunx create-gametau my-game -t vanilla   # Canvas2D
 
 cd my-game
 bun install
-bun run dev                              # localhost:1420 — hot-reload in Chrome
+bun run dev                              # Opens localhost:1420 in your browser
 ```
 
-Need current onboarding/release context? See [repository milestones](https://github.com/devallibus/gametau/milestones).
+That's it. Your game is running as WASM in the browser with hot-reload on Rust file saves.
 
-Integration-readiness gate references:
-- `RUNTIME-PORTABILITY-READINESS.md`
-- `INTEGRATION-PROXY-VALIDATION.md`
+### 2. Prerequisites
 
-For the experimental Electrobun runtime gate, see [active milestones](https://github.com/devallibus/gametau/milestones).
-
-### API docs
-
-- Live API docs: <https://gametau.devallibus.com/api/>
-- Generated automatically from TypeDoc + rustdoc in CI and deployed via Cloudflare Workers.
-
-### Environments and branches
-
-- `master` deploys production assets to Worker `gametau-prod` (`gametau.devallibus.com`).
-- `development` deploys staging assets to Worker `gametau-dev` (`dev.gametau.devallibus.com`).
-- Deployment workflows:
-  - `.github/workflows/deploy-workers-prod.yml`
-  - `.github/workflows/deploy-workers-staging.yml`
-- Required GitHub secrets:
-  - `CLOUDFLARE_ACCOUNT_ID`
-  - `CLOUDFLARE_API_TOKEN`
-- Deployment runbook: `.github/release/WORKERS-DEPLOYMENT.md`
-
-### Existing Tauri project
-
-```bash
-bun add webtau                           # runtime bridge (npm)
-bun add -D webtau-vite                   # Vite plugin
-cargo add webtau                         # wasm_state! macro (in your wasm crate)
-```
-
-Then follow [Migrating an Existing Tauri Game](#migrating-an-existing-tauri-game) below.
-
-### Build targets
-
-| Target | Command | Output |
-|---|---|---|
-| **Dev** | `bun run dev` | `localhost:1420` — hot-reload, no Tauri needed |
-| **Web** | `bun run build:web` | Static files for itch.io, Cloudflare Workers static assets, any host |
-| **Desktop (Stable)** | `bun run build:desktop` | Steam-ready `.exe` / `.dmg` / `.AppImage` via Tauri |
-| **Desktop (Experimental)** | See [active milestones](https://github.com/devallibus/gametau/milestones) | Electrobun trial path (opt-in, not default) |
-
-### Prerequisites
-
-- [Rust](https://rustup.rs/) with `wasm32-unknown-unknown` target
-- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) (required for fresh Rust/WASM builds and Rust watch rebuilds)
+- [Rust](https://rustup.rs/) with the `wasm32-unknown-unknown` target
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) — required for WASM builds and hot-reload
 - [Bun](https://bun.sh/) (or Node.js 18+)
-- [Tauri CLI](https://v2.tauri.app/start/create-project/) (stable desktop builds)
-- Electrobun tooling (experimental path only; see [active milestones](https://github.com/devallibus/gametau/milestones))
+- [Tauri CLI](https://v2.tauri.app/start/create-project/) — only needed for desktop builds
 
 ```bash
 rustup target add wasm32-unknown-unknown
 cargo install wasm-pack
-bun add -g @tauri-apps/cli    # optional, only for desktop builds
+bun add -g @tauri-apps/cli    # optional — only for desktop builds
 ```
 
----
+### 3. Write game logic in Rust
 
-## How It Works
-
-```mermaid
-flowchart TD
-    classDef rust fill:#dea584,stroke:#000,stroke-width:2px,color:#000
-    classDef tauri fill:#ffc131,stroke:#000,stroke-width:2px,color:#000
-    classDef web fill:#264de4,stroke:#000,stroke-width:2px,color:#fff
-    classDef bridge fill:#8a2be2,stroke:#000,stroke-width:2px,color:#fff
-    classDef frontend fill:#f7df1e,stroke:#000,stroke-width:2px,color:#000
-
-    RustCore["🦀 Rust Game Logic<br><code>core/</code> crate"]:::rust
-
-    RustCore -->|cargo build| Native["Tauri Build<br>Native OS"]:::tauri
-    RustCore -->|wasm-pack| Wasm["Web Build<br>WASM"]:::web
-
-    Native --> NativeState["#[tauri::command]<br>State&lt;Mutex&lt;T&gt;&gt;"]:::tauri
-    Wasm --> WasmState["#[wasm_bindgen]<br>thread_local!{RefCell&lt;T&gt;}"]:::web
-
-    NativeState --> IPC["Tauri IPC"]:::tauri
-    WasmState --> Direct["Direct WASM Call"]:::web
-
-    IPC --> Bridge{"webtau Bridge<br>(Auto-routes based on env)"}:::bridge
-    Direct --> Bridge
-
-    Bridge --> JS["invoke('tick_world')<br>Unified Frontend JS/TS"]:::frontend
-```
-
-Your frontend calls `invoke("command_name")` everywhere. At runtime:
-- **Inside Tauri** → routes through Tauri IPC (native speed)
-- **In a browser** → calls the WASM export directly
-- **With a registered runtime provider** → routes through the provider (experimental runtime bridge path)
-
-The switch is automatic. Zero `if` statements in your game code.
-
----
-
-## Why gametau?
-
-Tauri is right for the desktop side, but Tauri has no web target — `invoke()` routes through IPC that only exists inside the Tauri process. Without gametau, your dev loop is locked to `tauri dev` and your shareable web build is gone.
-
-gametau gives it all back:
-
-- **Dev in Chrome** — `bun run dev` gives you a fully working game in any browser tab. Full DevTools, fast HMR, shareable dev URLs. Drop into `tauri dev` only when testing desktop-specific behavior.
-- **No GC pauses** — Rust has no garbage collector. Your simulation ticks at a consistent cost every frame, not whenever JS decides to collect.
-- **2-5x faster for heavy logic** — Physics, pathfinding, large entity counts run measurably faster in WASM than equivalent JS. On desktop, it's full native code with no JS engine in the loop.
-- **Portable core** — The `core/` crate has zero framework dependencies. Reuse it for a multiplayer server, a new target, or anywhere else.
-
-| Feature | 🌐 Pure Web (JS) | 🦀 gametau (Rust + WASM/Tauri) |
-| :--- | :---: | :---: |
-| **Ships to Steam/Native** | ❌ No | ✅ Yes |
-| **Shareable web build** | ✅ Yes | ✅ Yes |
-| **Heavy simulation** | ⚠️ JS + GC limits | ⚡ WASM / Native |
-| **OS access (saves, files)** | 🔒 Browser APIs only | 🔓 Full native via Tauri |
-| **Game state correctness** | 🐛 Runtime surprises | 🛡️ Rust compile-time guarantees |
-| **Reuse logic on a server** | 🔄 Rewrite in Node | 📦 Same `core/` crate |
-
----
-
-## Packages
-
-gametau ships three packages that work together. The runtime bridge (`webtau`) handles your game's Rust↔JS communication. The Vite plugin (`webtau-vite`) automates builds. The scaffolder (`create-gametau`) wires everything up for new projects.
-
-You can install them individually or use the scaffolder to get all three at once.
-
-```mermaid
-mindmap
-  root((gametau))
-    webtau
-      Runtime Bridge
-      Seamless Rust ↔ JS
-      Tauri IPC router
-      WASM state shims
-    webtau-vite
-      Build Automation
-      Compiles Rust to WASM
-      Hot-reloads on save
-      Zero-config paths
-    create-gametau
-      Scaffolder
-      Generates Workspace
-      Three.js / PixiJS / Canvas
-      Ready-to-run setup
-```
-
----
-
-## `webtau` — Runtime Bridge
-
-Two packages with the same name on different registries — they work together.
-
-```bash
-bun add webtau            # npm — invoke() router + Tauri API shims
-cargo add webtau          # Rust — wasm_state! macro
-```
-
-The npm package provides the frontend interface. The Rust crate provides the WASM state management. Together, they let you call the same `invoke("command")` on both platforms.
-
-### `invoke<T>(command, args?)`
-
-Universal IPC — routes to Tauri or WASM automatically.
-
-```typescript
-import { invoke } from "webtau";
-
-const view = await invoke<WorldView>("get_world_view");
-const result = await invoke<TickResult>("tick_world", { speed: 2 });
-```
-
-In web mode, args are passed as a **single object** to the WASM export (matching Tauri's named-args semantics). Your `#[wasm_bindgen]` function should accept a `JsValue` and deserialize with `serde_wasm_bindgen::from_value()`.
-
-**Error behavior (web mode):**
-
-| Situation | Error message |
-|---|---|
-| `invoke()` before `configure()` | Includes exact `configure()` call pattern to fix it |
-| WASM export not found | Lists all available exported function names |
-| WASM module fails to load | Calls `onLoadError` callback, then rethrows — next `invoke()` retries the load |
-| Command/provider execution failure | Throws `WebtauError` with `code`, `runtime`, `command`, `message`, `hint` |
-
-Loading is deduplicated: concurrent `invoke()` calls while the WASM module is still loading share the same promise. After a load failure, the promise is cleared so subsequent calls can retry.
-
-### `configure(config)`
-
-Configure the WASM module loader for web builds. No-op when running inside Tauri.
-
-```typescript
-import { configure, isTauri } from "webtau";
-
-if (!isTauri()) {
-  configure({
-    loadWasm: async () => {
-      const wasm = await import("./wasm/my_game_wasm");
-      await wasm.default();
-      wasm.init();
-      return wasm;
-    },
-    onLoadError: (err) => console.error(err),  // optional
-  });
-}
-```
-
-### `isTauri()`
-
-Returns `true` when running inside Tauri (checks `window.__TAURI_INTERNALS__`).
-
-### `wasm_state!(Type)` (Rust crate)
-
-Generates thread-local state management for WASM. Replaces Tauri's `State<Mutex<T>>` pattern for the browser target.
-
-```rust
-use wasm_bindgen::prelude::*;
-use serde_wasm_bindgen::to_value;
-use my_game_core::GameWorld;
-
-webtau::wasm_state!(GameWorld);
-
-#[wasm_bindgen]
-pub fn init() { set_state(GameWorld::new()); }
-
-#[wasm_bindgen]
-pub fn get_world_view() -> JsValue {
-    with_state(|w| to_value(&w.view()).unwrap())
-}
-
-#[wasm_bindgen]
-pub fn tick_world() -> JsValue {
-    with_state_mut(|w| to_value(&w.tick()).unwrap())
-}
-```
-
-Expands to:
-
-- **`set_state(val: T)`** — Initialize or replace the state
-- **`with_state(|state| ...)`** — Read-only access (panics if not initialized)
-- **`with_state_mut(|state| ...)`** — Mutable access (panics if not initialized)
-
-### `#[webtau::command]` — Shared Command Definitions (Rust crate)
-
-Write your command once. The macro generates both `#[tauri::command]` (desktop) and `#[wasm_bindgen]` (web) wrappers automatically.
-
-```rust
-// src-tauri/commands/src/commands.rs
-use my_game_core::{GameWorld, WorldView, TickResult};
-
-#[cfg(target_arch = "wasm32")]
-webtau::wasm_state!(GameWorld);
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen::prelude::wasm_bindgen]
-pub fn init() { set_state(GameWorld::new()); }
-
-#[webtau::command]
-pub fn get_world_view(state: &GameWorld) -> WorldView {
-    state.view()
-}
-
-#[webtau::command]
-pub fn tick_world(state: &mut GameWorld) -> TickResult {
-    state.tick()
-}
-```
-
-**Contract:**
-- First parameter must be a reference: `&T` (read-only) or `&mut T` (mutable). Any identifier works (`state`, `world`, `game`, etc.)
-- Additional parameters become named args: `fn tick(state: &mut Game, dt: f64, input: i32)`
-- Return type can be `T` (serialized), `Result<T, E>` (errors surface to JS), or `()` (nothing)
-
-**Generated code (you never write this):**
-- `#[cfg(not(wasm32))]` — `#[tauri::command]` wrapper with `State<Mutex<T>>`
-- `#[cfg(wasm32)]` — `#[wasm_bindgen]` wrapper with args-object deserialize via `serde_wasm_bindgen`
-
-**Important:** Place commands in a submodule (not at crate root) to avoid conflicts with Tauri's internal `#[macro_export]`. The scaffolder does this automatically.
-
-### Tauri API Shims
-
-When `webtau-vite` aliases `@tauri-apps/api/*` imports to `webtau/*`, these shims provide browser-compatible implementations:
-
-Parity gaps are tracked in the [issue tracker](https://github.com/devallibus/gametau/issues).
-
-**`webtau/window`** — Web shim for `@tauri-apps/api/window`. Import `getCurrentWindow()` — same API as Tauri.
-
-| Method | Web Implementation |
-|---|---|
-| `isFullscreen()` | `document.fullscreenElement` |
-| `setFullscreen(bool)` | Fullscreen API |
-| `setTitle(string)` | `document.title` |
-| `setSize(LogicalSize)` | `window.resizeTo()` |
-| `currentMonitor()` | `screen.width/height` |
-| `setDecorations(bool)` | No-op |
-| `center()` | `window.moveTo()` |
-
-**`webtau/dpi`** — Web shim for `@tauri-apps/api/dpi`. Exports `LogicalSize`, `PhysicalSize`, `LogicalPosition`, `PhysicalPosition` with conversion methods.
-
-**`webtau/fs`** — Web shim for `@tauri-apps/api/fs`, backed by IndexedDB (in-memory fallback in non-browser test environments).
-
-| Method | Web Implementation |
-|---|---|
-| `writeTextFile(path, text)` | Stores file entry in IndexedDB |
-| `readTextFile(path)` | Loads text from IndexedDB |
-| `writeFile(path, bytes)` | Stores binary payload (`Uint8Array`) |
-| `readFile(path)` | Reads binary payload |
-| `createDir(path, { recursive })` | Creates directory entries in virtual FS |
-| `readDir(path, { recursive })` | Lists virtual FS entries |
-| `remove(path, { recursive })` | Removes file/dir entries |
-
-**`webtau/dialog`** — Web shim for `@tauri-apps/api/dialog`.
-
-| Method | Web Implementation |
-|---|---|
-| `message()` | HTML `<dialog>` modal (fallback: `alert`) |
-| `ask()` / `confirm()` | HTML `<dialog>` confirm (fallback: `confirm`) |
-| `open()` | Hidden file input picker (`<input type="file">`) |
-| `save()` | HTML `<dialog>` text input (fallback: `prompt`) |
-
-**`webtau/event`** — Web shim for `@tauri-apps/api/event`, using `CustomEvent` dispatch/listen semantics.
-
-| Method | Web Implementation |
-|---|---|
-| `listen(event, cb)` | `window.addEventListener` bridge |
-| `once(event, cb)` | Auto-unlisten after first callback |
-| `emit(event, payload)` | `window.dispatchEvent(new CustomEvent(...))` |
-| `emitTo(target, event, payload)` | Web-mode alias of `emit` |
-
-**`webtau/adapters/tauri`** — Optional Tauri bootstrap helpers for explicit provider + event wiring.
-
-| API | Purpose |
-|---|---|
-| `bootstrapTauri()` | Registers Tauri core provider + event adapter in one call |
-| `createTauriCoreProvider()` | Returns a `CoreProvider` wrapper around `@tauri-apps/api/core` |
-| `createTauriEventAdapter()` | Returns an `EventAdapter` wrapper around `@tauri-apps/api/event` |
-
-**`webtau/task`** — Non-blocking lifecycle helpers for long-running backend work.
-
-| API | Purpose |
-|---|---|
-| `startTask(command, args, options?)` | Starts work and returns `taskId` immediately |
-| `pollTask(taskId)` | Returns current state (`running`, `completed`, `cancelled`, `failed`) |
-| `cancelTask(taskId)` | Cancels task state and triggers `options.onCancel` when provided |
-| `updateTaskProgress(taskId, progress)` | Provider/test helper for progress updates |
-
-Task cancellation is cooperative. Provide `onCancel` in `startTask(..., { onCancel })` to propagate cancellation to backend work.
-
-**`webtau/app`** — Web shim for `@tauri-apps/api/app`.
-
-| Method | Web Implementation |
-|---|---|
-| `getName()` | Configured app name, then `document.title`, then `"gametau-app"` |
-| `getVersion()` | Configured app version, then `"0.0.0"` |
-| `getTauriVersion()` | `"web"` sentinel in browser mode |
-| `show()` / `hide()` | No-op in browser tabs |
-| `setAppName(name \| null)` / `setAppVersion(version \| null)` | webtau-specific fallback configurators |
-
-**`webtau/path`** — Web shim for `@tauri-apps/api/path`.
-
-| Method Group | Web Implementation |
-|---|---|
-| Virtual dirs (`appDataDir`, `appConfigDir`, `homeDir`, etc.) | Deterministic virtual `/app/*` paths for browser usage |
-| `basename`, `dirname`, `extname`, `join`, `normalize`, `resolve`, `isAbsolute`, `sep` | POSIX-style path utilities for web mode |
-
-Not all Tauri `path` APIs are implemented yet (for example `resolveResource`). Gaps are tracked in the [issue tracker](https://github.com/devallibus/gametau/issues).
-
-### Gameplay foundation modules
-
-These modules provide a lightweight, browser-first baseline for common game subsystems:
-
-**`webtau/input`** — unified input abstraction for keyboard, gamepad, touch, and pointer-lock mouse deltas.
-
-| Method | Purpose |
-|---|---|
-| `keyAxis(negative, positive)` | Digital axis from key bindings |
-| `gamepadAxis(axis, options)` | Analog axis read with deadzone/invert |
-| `touches()` | Active touch positions |
-| `requestPointerLock(element)` | Pointer-lock opt-in for mouse-look style controls |
-| `consumePointerDelta()` | Relative mouse delta since last frame |
-
-**`webtau/audio`** — minimal Web Audio wrapper with mute/volume controls and quick tone playback.
-
-| Method | Purpose |
-|---|---|
-| `resume()` / `suspend()` | Unlock or suspend audio context |
-| `setMuted(bool)` | Global mute toggle |
-| `setMasterVolume(value)` | Master gain control (`0..1`) |
-| `playTone(freq, durationMs, options)` | Lightweight SFX/beep synthesis |
-
-**`webtau/assets`** — cached loader helpers for text/json/binary/image assets.
-
-| Method | Purpose |
-|---|---|
-| `loadText(url)` | Fetch text assets |
-| `loadJson<T>(url)` | Fetch + parse JSON assets |
-| `loadBytes(url)` | Fetch binary payloads |
-| `loadImage(url)` | Load image via `Image` object |
-| `clear()` | Clear loader cache |
-
-Example integration paths:
-
-- `examples/pong` uses the three foundation modules together (input + audio + theme asset loading).
-- `examples/battlestation` is the flagship full-stack showcase (runtime bridge + `app`, `event`, `fs/path`, and foundation modules).
-
----
-
-## `webtau-vite` — Vite Plugin
-
-Automates wasm-pack builds, watches Rust files for hot-reload, and aliases `@tauri-apps/api/*` imports to the `webtau` shims above.
-
-```bash
-bun add -D webtau-vite
-```
-
-```typescript
-// vite.config.ts
-import { defineConfig } from "vite";
-import webtauVite from "webtau-vite";
-
-export default defineConfig({
-  plugins: [webtauVite()],
-});
-```
-
-Zero config for the standard layout (`src-tauri/wasm`, `src-tauri/core`, etc.) — the plugin auto-detects crate paths and watch directories.
-
-### What it does per mode
-
-| Feature | `vite dev` (web) | `vite build` (web) | `tauri dev`/`tauri build` |
-|---|---|---|---|
-| wasm-pack | `--dev` | `--release` | Skipped |
-| Rust file watching | Chokidar → full-reload | N/A | Skipped |
-| Import aliasing | `@tauri-apps/api/*` → `webtau/*` | Same | Disabled |
-| wasm-opt | N/A | Optional (`wasmOpt: true`) | Skipped |
-
-### Options
-
-All optional — override only for non-standard layouts:
-
-```typescript
-webtauVite({
-  wasmCrate: "src-tauri/wasm",      // Path to WASM crate (default)
-  wasmOutDir: "src/wasm",           // wasm-pack output directory (default)
-  watchPaths: [],                    // Extra dirs to watch (sibling crates auto-detected)
-  wasmOpt: false,                    // Run wasm-opt on release (default)
-})
-```
-
-### `wasm-pack` requirement and fallback semantics
-
-- Fresh Rust/WASM builds and the dev rebuild loop require `wasm-pack`.
-- If `wasm-pack` is missing but valid prebuilt output already exists in `wasmOutDir`, `webtau-vite` reuses it and continues.
-- In this fallback mode, Rust watch rebuilds are intentionally disabled until `wasm-pack` is installed.
-- If `wasm-pack` is missing and reusable prebuilt artifacts are unavailable or incomplete, the plugin fails fast with a clear error.
-
----
-
-## `create-gametau` — Project Scaffolder
-
-Generates a complete project with `webtau`, `webtau-vite`, and a Rust workspace already wired up.
-
-```bash
-bunx create-gametau my-game              # Three.js (default)
-bunx create-gametau my-game -t pixi      # PixiJS
-bunx create-gametau my-game -t vanilla   # Canvas2D
-```
-
-### Scaffolded project structure
-
-```
-my-game/
-  src-tauri/
-    Cargo.toml              # Rust workspace: [core, commands, app, wasm]
-    core/                   # Pure game logic (no framework deps)
-      src/lib.rs            # GameWorld struct + methods
-    commands/               # Shared command definitions (v2)
-      src/lib.rs            # Re-exports from submodule
-      src/commands.rs       # #[webtau::command] functions
-    app/                    # Tauri desktop shell
-      src/lib.rs            # generate_handler! + state setup
-      tauri.conf.json
-    wasm/                   # WASM entry point
-      src/lib.rs            # Links commands crate (exports auto-wired)
-  src/
-    index.ts                # Entry point
-    game/scene.ts           # Three.js / PixiJS / Canvas2D scene
-    game/loop.ts            # requestAnimationFrame + tick integration
-    services/backend.ts     # Typed invoke() wrappers
-    services/settings.ts    # Runtime settings persistence (webtau/path + webtau/fs)
-    services/session.ts     # Mission/session snapshots (webtau/path + webtau/fs)
-    services/comms.ts       # Event-driven comms/alerts (webtau/event)
-    services/contracts.ts   # Service-layer interfaces and shared types
-  package.json
-  vite.config.ts            # Pre-configured with webtau-vite
-```
-
----
-
-## Putting It All Together
-
-Here's how the three packages connect in a typical project. Whether you scaffolded with `create-gametau` or added the packages manually, the code is the same.
-
-### 1. Write game logic in Rust (`core/`)
-
-Your core crate is pure Rust — no Tauri, no WASM dependencies. Just your game state and logic.
+Start with a pure Rust crate. No Tauri, no WASM imports — just your game state and logic.
 
 ```rust
 // src-tauri/core/src/lib.rs
@@ -571,9 +83,11 @@ impl GameWorld {
 }
 ```
 
-### 2. Define commands once (`commands/`)
+The `core/` crate is pure Rust with no framework dependencies. Reuse it for a multiplayer server, a CLI tool, or any future target without modification.
 
-Use `#[webtau::command]` to write each command once. The macro generates both Tauri and WASM wrappers.
+### 4. Define commands once
+
+Use `#[webtau::command]` to write each command once. The macro generates both the Tauri and WASM wrappers automatically — you never write them by hand.
 
 ```rust
 // src-tauri/commands/src/commands.rs
@@ -608,9 +122,20 @@ pub use commands::{get_world_view, tick_world};
 pub use commands::{init, get_world_view, tick_world};
 ```
 
-### 3. Wire up Tauri (`app/`)
+**Command contract:**
+- First parameter is a reference to your state type: `&T` (read-only) or `&mut T` (mutable). Any name works.
+- Additional parameters become named args on the JS side.
+- Return `T` (serialized), `Result<T, E>` (errors surface to JS), or `()`.
 
-The app crate imports the shared commands and registers them:
+**What the macro generates** (you never write this):
+- `#[cfg(not(wasm32))]` — a `#[tauri::command]` wrapper with `State<Mutex<T>>`
+- `#[cfg(wasm32)]` — a `#[wasm_bindgen]` wrapper that deserializes a single args object via `serde_wasm_bindgen`
+
+> **Note:** Place commands in a submodule (not at crate root) to avoid conflicts with Tauri's `#[macro_export]`. The scaffolder handles this automatically.
+
+### 5. Wire up Tauri and WASM
+
+The `app/` crate registers the commands with Tauri:
 
 ```rust
 // src-tauri/app/src/lib.rs
@@ -627,16 +152,16 @@ pub fn run() {
 }
 ```
 
-### 4. Wire up WASM (`wasm/`)
-
-The wasm crate just links the commands — exports are auto-wired through `wasm_bindgen`:
+The `wasm/` crate just links the commands — `wasm_bindgen` wires the exports automatically:
 
 ```rust
 // src-tauri/wasm/src/lib.rs
 use my_game_commands as _;
 ```
 
-### 5. Call from frontend — uses `webtau` npm package
+### 6. Call from your frontend
+
+Replace `@tauri-apps/api/core` with `webtau` everywhere. The call is identical on both platforms.
 
 ```typescript
 // src/services/backend.ts
@@ -646,8 +171,10 @@ export const getWorldView = () => invoke<WorldView>("get_world_view");
 export const tickWorld = () => invoke<TickResult>("tick_world");
 ```
 
+Configure the WASM loader for web mode in your entry point:
+
 ```typescript
-// src/index.ts — configure() for web mode
+// src/index.ts
 import { configure, isTauri } from "webtau";
 
 if (!isTauri()) {
@@ -661,10 +188,312 @@ if (!isTauri()) {
   });
 }
 
-// From here on, getWorldView() and tickWorld() work on both platforms
+// From here, getWorldView() and tickWorld() work on both platforms.
 ```
 
-### 6. Configure Vite — uses `webtau-vite`
+### 7. Configure Vite
+
+Add the plugin to `vite.config.ts`:
+
+```typescript
+import { defineConfig } from "vite";
+import webtauVite from "webtau-vite";
+
+export default defineConfig({
+  plugins: [webtauVite()],
+});
+```
+
+That's all. The plugin auto-detects your crate paths, compiles Rust to WASM on startup, watches for changes, and aliases `@tauri-apps/api/*` imports to the webtau shims.
+
+### Build targets
+
+| Target | Command | Output |
+|---|---|---|
+| **Dev** | `bun run dev` | `localhost:1420` — hot-reload, no Tauri needed |
+| **Web** | `bun run build:web` | Static files for itch.io, Cloudflare Workers, any host |
+| **Desktop (Stable)** | `bun run build:desktop` | Steam-ready `.exe` / `.dmg` / `.AppImage` via Tauri |
+
+---
+
+## How it works
+
+```mermaid
+flowchart TD
+    classDef rust fill:#dea584,stroke:#000,stroke-width:2px,color:#000
+    classDef tauri fill:#ffc131,stroke:#000,stroke-width:2px,color:#000
+    classDef web fill:#264de4,stroke:#000,stroke-width:2px,color:#fff
+    classDef bridge fill:#8a2be2,stroke:#000,stroke-width:2px,color:#fff
+    classDef frontend fill:#f7df1e,stroke:#000,stroke-width:2px,color:#000
+
+    RustCore["🦀 Rust Game Logic<br><code>core/</code> crate"]:::rust
+
+    RustCore -->|cargo build| Native["Tauri Build<br>Native OS"]:::tauri
+    RustCore -->|wasm-pack| Wasm["Web Build<br>WASM"]:::web
+
+    Native --> NativeState["#[tauri::command]<br>State&lt;Mutex&lt;T&gt;&gt;"]:::tauri
+    Wasm --> WasmState["#[wasm_bindgen]<br>thread_local!{RefCell&lt;T&gt;}"]:::web
+
+    NativeState --> IPC["Tauri IPC"]:::tauri
+    WasmState --> Direct["Direct WASM Call"]:::web
+
+    IPC --> Bridge{"webtau Bridge<br>(Auto-routes based on env)"}:::bridge
+    Direct --> Bridge
+
+    Bridge --> JS["invoke('tick_world')<br>Unified Frontend JS/TS"]:::frontend
+```
+
+Your frontend calls `invoke("command_name")` everywhere. At runtime:
+
+- **Inside Tauri** → routes through Tauri IPC at native speed
+- **In a browser** → calls the WASM export directly
+- **With a registered runtime provider** → routes through the provider (for experimental runtimes)
+
+The switch is automatic. Zero `if` statements in your game code.
+
+---
+
+## Why gametau?
+
+| Feature | 🌐 Pure Web (JS) | 🦀 gametau (Rust + WASM/Tauri) |
+| :--- | :---: | :---: |
+| **Ships to Steam/Native** | ❌ No | ✅ Yes |
+| **Shareable web build** | ✅ Yes | ✅ Yes |
+| **Heavy simulation** | ⚠️ JS + GC limits | ⚡ WASM / Native |
+| **OS access (saves, files)** | 🔒 Browser APIs only | 🔓 Full native via Tauri |
+| **Game state correctness** | 🐛 Runtime surprises | 🛡️ Rust compile-time guarantees |
+| **Reuse logic on a server** | 🔄 Rewrite in Node | 📦 Same `core/` crate |
+
+**Dev in Chrome** — `bun run dev` gives you a working game in any browser tab. Full DevTools, fast HMR, shareable URLs. Drop into `tauri dev` only when testing desktop-specific behavior.
+
+**No GC pauses** — Rust has no garbage collector. Your simulation ticks at a consistent cost every frame.
+
+**2–5x faster for heavy logic** — Physics, pathfinding, large entity counts run measurably faster in WASM than equivalent JS. On desktop it's full native code with no JS engine in the loop.
+
+**Portable core** — the `core/` crate has zero framework dependencies. Reuse it for a multiplayer server, a new target, or anywhere else Rust runs.
+
+---
+
+## Packages
+
+### `webtau` — Runtime Bridge
+
+Two packages with the same name on different registries that work together:
+
+```bash
+bun add webtau            # npm — invoke() router + Tauri API shims
+cargo add webtau          # Rust — wasm_state! macro + #[webtau::command]
+```
+
+#### `invoke<T>(command, args?)`
+
+Universal IPC. Routes to Tauri or WASM automatically.
+
+```typescript
+import { invoke } from "webtau";
+
+const view = await invoke<WorldView>("get_world_view");
+const result = await invoke<TickResult>("tick_world", { speed: 2 });
+```
+
+In web mode, args are passed as a single object to the WASM export (matching Tauri's named-args semantics). Your `#[wasm_bindgen]` function accepts a `JsValue` and deserializes with `serde_wasm_bindgen::from_value()`.
+
+**Error behavior (web mode):**
+
+| Situation | Error |
+|---|---|
+| `invoke()` before `configure()` | `WebtauError` with the exact `configure()` call pattern to fix it |
+| WASM export not found | `WebtauError` listing all available exported function names |
+| WASM module fails to load | Calls `onLoadError` callback, then rethrows — next `invoke()` retries the load |
+| Command or provider failure | `WebtauError` with `code`, `runtime`, `command`, `message`, `hint` |
+
+Concurrent `invoke()` calls while the module is loading share the same promise. After a load failure the promise clears so subsequent calls retry.
+
+#### `configure(config)`
+
+Configure the WASM module loader for web builds. No-op inside Tauri.
+
+```typescript
+import { configure, isTauri } from "webtau";
+
+if (!isTauri()) {
+  configure({
+    loadWasm: async () => {
+      const wasm = await import("./wasm/my_game_wasm");
+      await wasm.default();
+      wasm.init();
+      return wasm;
+    },
+    onLoadError: (err) => console.error(err),  // optional
+  });
+}
+```
+
+#### `isTauri()`
+
+Returns `true` when running inside Tauri (checks `window.__TAURI_INTERNALS__`).
+
+#### `wasm_state!(Type)` (Rust crate)
+
+Generates thread-local state management for WASM. Replaces Tauri's `State<Mutex<T>>` for the browser target.
+
+```rust
+use wasm_bindgen::prelude::*;
+use serde_wasm_bindgen::to_value;
+use my_game_core::GameWorld;
+
+webtau::wasm_state!(GameWorld);
+
+#[wasm_bindgen]
+pub fn init() { set_state(GameWorld::new()); }
+
+#[wasm_bindgen]
+pub fn get_world_view() -> JsValue {
+    with_state(|w| to_value(&w.view()).unwrap())
+}
+
+#[wasm_bindgen]
+pub fn tick_world() -> JsValue {
+    with_state_mut(|w| to_value(&w.tick()).unwrap())
+}
+```
+
+Expands to:
+
+- **`set_state(val: T)`** — Initialize or replace the state
+- **`with_state(|state| ...)`** — Read-only access (panics if uninitialized)
+- **`with_state_mut(|state| ...)`** — Mutable access (panics if uninitialized)
+- **`try_with_state(|state| ...)`** — Read-only access, returns `None` if uninitialized
+- **`try_with_state_mut(|state| ...)`** — Mutable access, returns `None` if uninitialized
+
+#### Tauri API Shims
+
+`webtau-vite` aliases `@tauri-apps/api/*` imports to `webtau/*` in web builds, so the same import paths work everywhere. Parity gaps are tracked in the [issue tracker](https://github.com/devallibus/gametau/issues).
+
+**`webtau/window`** — shim for `@tauri-apps/api/window`. Import `getCurrentWindow()` — same API as Tauri.
+
+| Method | Web implementation |
+|---|---|
+| `isFullscreen()` | `document.fullscreenElement` |
+| `setFullscreen(bool)` | Fullscreen API |
+| `setTitle(string)` | `document.title` |
+| `setSize(LogicalSize)` | `window.resizeTo()` |
+| `currentMonitor()` | `screen.width/height` |
+| `setDecorations(bool)` | No-op |
+| `center()` | `window.moveTo()` |
+
+**`webtau/dpi`** — shim for `@tauri-apps/api/dpi`. Exports `LogicalSize`, `PhysicalSize`, `LogicalPosition`, `PhysicalPosition` with conversion methods.
+
+**`webtau/fs`** — shim for `@tauri-apps/api/fs`, backed by IndexedDB.
+
+| Method | Web implementation |
+|---|---|
+| `writeTextFile(path, text)` | IndexedDB |
+| `readTextFile(path)` | IndexedDB |
+| `writeFile(path, bytes)` | IndexedDB (binary) |
+| `readFile(path)` | IndexedDB (binary) |
+| `createDir(path, { recursive })` | Virtual FS |
+| `readDir(path, { recursive })` | Virtual FS listing |
+| `remove(path, { recursive })` | Virtual FS |
+| `copyFile(src, dest)` | Virtual FS |
+| `rename(src, dest)` | Virtual FS |
+
+**`webtau/dialog`** — shim for `@tauri-apps/api/dialog`.
+
+| Method | Web implementation |
+|---|---|
+| `message()` | HTML `<dialog>` modal (fallback: `alert`) |
+| `ask()` / `confirm()` | HTML `<dialog>` confirm (fallback: `confirm`) |
+| `open()` | `<input type="file">` |
+| `save()` | HTML `<dialog>` text input (fallback: `prompt`) |
+
+**`webtau/event`** — shim for `@tauri-apps/api/event`, using `CustomEvent` dispatch/listen semantics.
+
+| Method | Web implementation |
+|---|---|
+| `listen(event, cb)` | `window.addEventListener` bridge |
+| `once(event, cb)` | Auto-unlistens after first callback |
+| `emit(event, payload)` | `window.dispatchEvent(new CustomEvent(...))` |
+| `emitTo(target, event, payload)` | Alias of `emit` in web mode |
+
+**`webtau/app`** — shim for `@tauri-apps/api/app`.
+
+| Method | Web implementation |
+|---|---|
+| `getName()` | Configured name → `document.title` → `"gametau-app"` |
+| `getVersion()` | Configured version → `"0.0.0"` |
+| `getTauriVersion()` | `"web"` sentinel |
+| `show()` / `hide()` | No-op |
+| `setAppName(name)` / `setAppVersion(version)` | webtau-specific fallback configurators |
+
+**`webtau/path`** — shim for `@tauri-apps/api/path`.
+
+| Method group | Web implementation |
+|---|---|
+| Virtual dirs (`appDataDir`, `appConfigDir`, `homeDir`, etc.) | Deterministic virtual `/app/*` paths |
+| `basename`, `dirname`, `extname`, `join`, `normalize`, `resolve`, `isAbsolute`, `delimiter`, `sep` | POSIX-style path utilities |
+
+`resolveResource` is not yet implemented. Gaps tracked in the [issue tracker](https://github.com/devallibus/gametau/issues).
+
+**`webtau/adapters/tauri`** — optional Tauri bootstrap helpers.
+
+| API | Purpose |
+|---|---|
+| `bootstrapTauri()` | Register the Tauri core provider and event adapter in one call |
+| `createTauriCoreProvider()` | `CoreProvider` wrapper around `@tauri-apps/api/core` |
+| `createTauriEventAdapter()` | `EventAdapter` wrapper around `@tauri-apps/api/event` |
+
+**`webtau/task`** — non-blocking lifecycle helpers for long-running backend work.
+
+| API | Purpose |
+|---|---|
+| `startTask(command, args, options?)` | Start work, return `taskId` immediately |
+| `pollTask(taskId)` | Return current state: `running`, `completed`, `cancelled`, or `failed` |
+| `cancelTask(taskId)` | Cancel and trigger `options.onCancel` when provided |
+| `updateTaskProgress(taskId, progress)` | Update progress from a provider or test |
+
+Cancellation is cooperative. Provide `onCancel` in `startTask` to propagate cancellation to backend work.
+
+#### Gameplay foundation modules
+
+**`webtau/input`** — unified input for keyboard, gamepad, touch, and pointer-lock mouse.
+
+| Method | Purpose |
+|---|---|
+| `keyAxis(negative, positive)` | Digital axis from key bindings |
+| `gamepadAxis(axis, options)` | Analog axis with deadzone/invert |
+| `touches()` | Active touch positions |
+| `requestPointerLock(element)` | Pointer-lock for mouse-look controls |
+| `consumePointerDelta()` | Relative mouse delta since last frame |
+
+**`webtau/audio`** — minimal Web Audio wrapper.
+
+| Method | Purpose |
+|---|---|
+| `resume()` / `suspend()` | Unlock or suspend the audio context |
+| `setMuted(bool)` | Global mute toggle |
+| `setMasterVolume(value)` | Master gain (`0..1`) |
+| `playTone(freq, durationMs, options)` | Lightweight SFX/beep synthesis |
+
+**`webtau/assets`** — cached loader helpers.
+
+| Method | Purpose |
+|---|---|
+| `loadText(url)` | Fetch text |
+| `loadJson<T>(url)` | Fetch and parse JSON |
+| `loadBytes(url)` | Fetch binary |
+| `loadImage(url)` | Load via `Image` object |
+| `clear()` | Clear the cache |
+
+---
+
+### `webtau-vite` — Vite Plugin
+
+Compiles Rust to WASM on save, watches for changes, and aliases `@tauri-apps/api/*` imports to the webtau shims in web builds.
+
+```bash
+bun add -D webtau-vite
+```
 
 ```typescript
 // vite.config.ts
@@ -675,6 +504,123 @@ export default defineConfig({
   plugins: [webtauVite()],
 });
 ```
+
+Zero config for the standard layout (`src-tauri/wasm`, `src-tauri/core`, etc.) — the plugin auto-detects crate paths and watch directories.
+
+#### What it does per mode
+
+| Feature | `vite dev` (web) | `vite build` (web) | `tauri dev` / `tauri build` |
+|---|---|---|---|
+| wasm-pack | `--dev` | `--release` | Skipped |
+| Rust file watching | Chokidar → full-reload | N/A | Skipped |
+| Import aliasing | `@tauri-apps/api/*` → `webtau/*` | Same | Disabled |
+| wasm-opt | N/A | Optional (`wasmOpt: true`) | Skipped |
+
+#### Options
+
+All optional — override only for non-standard layouts:
+
+```typescript
+webtauVite({
+  wasmCrate: "src-tauri/wasm",      // Path to the WASM crate (default)
+  wasmOutDir: "src/wasm",           // wasm-pack output directory (default)
+  watchPaths: [],                    // Extra dirs to watch (sibling crates auto-detected)
+  wasmOpt: false,                    // Run wasm-opt on release builds (default)
+})
+```
+
+#### `wasm-pack` and fallback behavior
+
+Fresh WASM builds and the hot-reload loop require `wasm-pack`. If `wasm-pack` is missing but valid prebuilt artifacts already exist in `wasmOutDir`, the plugin reuses them and continues — dev and web builds work, but Rust watch rebuilds are disabled until `wasm-pack` is installed. If `wasm-pack` is missing and no usable prebuilt artifacts exist, the plugin fails fast with a clear error.
+
+---
+
+### `create-gametau` — Project Scaffolder
+
+Generates a complete project with `webtau`, `webtau-vite`, and a Rust workspace already wired up.
+
+```bash
+bunx create-gametau my-game              # Three.js (default)
+bunx create-gametau my-game -t pixi      # PixiJS
+bunx create-gametau my-game -t vanilla   # Canvas2D
+```
+
+#### Scaffolded project structure
+
+```
+my-game/
+  src-tauri/
+    Cargo.toml              # Rust workspace: [core, commands, app, wasm]
+    core/                   # Pure game logic (no framework deps)
+      src/lib.rs            # GameWorld struct + methods
+    commands/               # Shared command definitions
+      src/lib.rs            # Re-exports from submodule
+      src/commands.rs       # #[webtau::command] functions
+    app/                    # Tauri desktop shell
+      src/lib.rs            # generate_handler! + state setup
+      tauri.conf.json
+    wasm/                   # WASM entry point
+      src/lib.rs            # Links commands crate (exports auto-wired)
+  src/
+    index.ts                # Entry point — configure() + bootstrapTauri()
+    game/scene.ts           # Three.js / PixiJS / Canvas2D scene
+    game/loop.ts            # requestAnimationFrame + tick integration
+    services/backend.ts     # Typed invoke() wrappers + task seams
+    services/settings.ts    # Runtime settings persistence (webtau/path + webtau/fs)
+    services/session.ts     # Mission/session snapshots
+    services/comms.ts       # Event-driven comms (webtau/event)
+    services/contracts.ts   # Shared interfaces and types
+  package.json
+  vite.config.ts            # Pre-configured with webtau-vite
+```
+
+---
+
+## Examples
+
+**[Live demos →](https://gametau.devallibus.com/)**
+
+- **[`examples/counter`](./examples/counter)** — The simplest possible gametau project. One counter with increment/decrement/reset, running as WASM in the browser and natively on desktop.
+- **[`examples/pong`](./examples/pong)** — Two-player Pong with Rust physics and PixiJS rendering. Demonstrates a real game loop, collision detection, and keyboard input across both targets.
+- **[`examples/battlestation`](./examples/battlestation)** — Flagship showcase. A tactical radar command loop using the full module surface (`input`, `audio`, `assets`, `fs/path`, `event`, `app`) with persistent player profile and a backend event-driven narrative. [Live demo →](https://gametau.devallibus.com/battlestation/)
+
+---
+
+## Migrating from an Existing Tauri Game
+
+Install the three packages:
+
+```bash
+bun add webtau
+bun add -D webtau-vite
+cargo add webtau          # in your commands crate
+```
+
+Then:
+
+1. **Extract core logic** into a separate `core/` crate with no Tauri deps.
+2. **Create a `commands/` crate** — define shared commands with `#[webtau::command]`.
+3. **Create a `wasm/` crate** with `crate-type = ["cdylib"]` that links `commands`.
+4. **Update `app/`** to import commands from `commands/` instead of defining them inline.
+5. **Replace** `import { invoke } from "@tauri-apps/api/core"` with `import { invoke } from "webtau"`.
+6. **Add `configure()`** in your entry point for web mode.
+7. **Add `webtau-vite`** to your `vite.config.ts`.
+
+### Migrating from v1 manual wrappers to v2 `#[webtau::command]`
+
+If you already use gametau v1 with separate per-platform wrappers:
+
+1. **Create a `commands/` crate** in your workspace.
+2. **Move command logic** from `app/src/lib.rs` into `commands/src/commands.rs`.
+3. **Replace** `#[tauri::command]` + `State<Mutex<T>>` with `#[webtau::command]` + `state: &T` / `state: &mut T`.
+4. **Move** `wasm_state!` and `init()` into `commands/src/commands.rs` behind `#[cfg(target_arch = "wasm32")]`.
+5. **Re-export** commands from `commands/src/lib.rs` with cfg-gated `pub use`.
+6. **Simplify `app/`** to just import and call `generate_handler!`.
+7. **Simplify `wasm/`** to just `use my_commands as _;`.
+
+Manual v1 wrappers remain fully supported — migrate command-by-command at your own pace.
+
+---
 
 ## WASM Optimization
 
@@ -689,67 +635,46 @@ strip = true
 ```
 
 Expected sizes:
-- Simple game (~600 LOC Rust): **50-100KB** WASM, ~20-40KB gzipped
-- Complex simulation (~2000+ LOC): **200-500KB** WASM, ~80-200KB gzipped
 
-## Examples
+- Simple game (~600 LOC Rust): **50–100 KB** WASM, ~20–40 KB gzipped
+- Complex simulation (~2000+ LOC): **200–500 KB** WASM, ~80–200 KB gzipped
 
-**[Live demos →](https://gametau.devallibus.com/)**
+---
 
-- **[`examples/counter`](./examples/counter)** — Simplest possible example. Counter with increment/decrement/reset that works on both web and desktop.
-- **[`examples/pong`](./examples/pong)** — Two-player Pong with Rust physics + PixiJS rendering. Demonstrates real game loop, collision detection, and keyboard input across both targets.
-- **[`examples/battlestation`](./examples/battlestation)** — Flagship tactical radar command loop demonstrating full module coverage (`input`, `audio`, `assets`, `fs/path`, `event`, `app`) with persistent profile + comms narrative. Live demo: <https://gametau.devallibus.com/battlestation/>.
+## Supported runtimes
 
-## Migrating an Existing Tauri Game
+| Runtime | Status |
+|---|---|
+| Web (WASM) | Stable |
+| Desktop (Tauri) | Stable |
+| Desktop (Electrobun) | Experimental — opt-in via `webtau@alpha` |
 
-Install the three packages:
+See [`RUNTIME-PORTABILITY-READINESS.md`](./RUNTIME-PORTABILITY-READINESS.md) for the full capability matrix and known gaps.
 
-```bash
-bun add webtau
-bun add -D webtau-vite
-cargo add webtau          # in your commands crate
-```
-
-Then:
-
-1. **Extract core logic** into a separate `core/` crate with no Tauri deps
-2. **Create a `commands/` crate** — define shared commands with `#[webtau::command]`
-3. **Create a `wasm/` crate** with `crate-type = ["cdylib"]` that links `commands`
-4. **Update `app/`** to import commands from `commands/` instead of defining them inline
-5. **Replace** `import { invoke } from "@tauri-apps/api/core"` with `import { invoke } from "webtau"`
-6. **Add `configure()`** call in your entry point for web mode
-7. **Add `webtau-vite`** to your `vite.config.ts`
-
-### Migrating from v1 Manual Wrappers to v2 `#[webtau::command]`
-
-If you already use gametau v1 with separate `app/` and `wasm/` wrappers:
-
-1. **Create `commands/` crate** in your workspace
-2. **Move command logic** from `app/src/lib.rs` into `commands/src/commands.rs`
-3. **Replace** `#[tauri::command]` + manual `State<Mutex<T>>` with `#[webtau::command]` + `state: &T` / `state: &mut T`
-4. **Move** `wasm_state!` and `init()` into `commands/src/commands.rs` behind `#[cfg(target_arch = "wasm32")]`
-5. **Re-export** commands from `commands/src/lib.rs` with cfg-gated `pub use`
-6. **Simplify `app/`** to just import + `generate_handler!`
-7. **Simplify `wasm/`** to just `use my_commands as _;`
-
-Manual v1 wrappers remain fully supported — you can migrate command-by-command at your own pace.
+---
 
 ## Roadmap
 
-- **`0.2.x` (historical stable line)**: docs/adoption + parity/foundation backlog delivered (`fs/dialog/event` shims and `input/audio/assets` modules). See [CHANGELOG `0.2.1`](./CHANGELOG.md#021---2026-02-26) and [roadmap issue #6](https://github.com/devallibus/gametau/issues/6).
-- **`0.4.0` (historical stable line)**: quality baseline uplift (CI lint gate + broader contract tests), battlestation scenario smoke coverage, release artifact integrity hardening, and parity tranche 1 (`core/app/path/fs`) expansion.
-- **`0.5.2` (current stable line)**: task lifecycle, Tauri adapter bootstrap, structured diagnostics, Node ESM import compatibility fix, and pre-publish ESM consumer smoke guardrails.
+- **Electrobun** — promote from experimental to stable once the trial track meets the same CI and smoke bar as Tauri
+- **Electrobun scaffolder integration** — make Electrobun a first-class template option in `create-gametau`
+- **Additional shim coverage** — fill remaining `webtau/path` gaps (`resolveResource`) and expand `webtau/window`
+- **Performance baselines** — published benchmarks for WASM vs native vs JS for common game workloads
+- **Advanced examples** — multiplayer server reusing the `core/` crate, plugin architecture examples
 
-## Support & Commercial Licensing
+Active work is tracked in [repository milestones](https://github.com/devallibus/gametau/milestones).
 
-Gametau is and will always be **100% free** under Apache 2.0 for everyone.
+---
 
-If your commercial game using Gametau reaches more than $100k lifetime revenue, we offer a simple
-optional commercial license with a gentle one-time donation (1%, min $2k, max $15k per game, due
-within one year). It's our way of saying thank you when things go well.
+## API docs
 
-Commercial licensing requests are handled in-repo via issues (open one labeled `commercial license`).
+Live API docs (TypeDoc + rustdoc, generated in CI): **<https://gametau.devallibus.com/api/>**
 
-Contributors also agree to our friendly [CLA](CLA.md).
+---
 
-Already successful? Just open an issue labeled `commercial license` — happy to help!
+## License & Contributing
+
+gametau is [Apache 2.0](LICENSE) licensed and will always be free to use.
+
+If your commercial game using gametau reaches more than $100k lifetime revenue, we offer an optional commercial license with a gentle one-time donation (1%, min $2k, max $15k per game, due within one year). Open an issue labeled `commercial license` to get started.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute, and [CLA.md](CLA.md) for the contributor agreement.

--- a/RUNTIME-PORTABILITY-READINESS.md
+++ b/RUNTIME-PORTABILITY-READINESS.md
@@ -1,120 +1,54 @@
-# Runtime Portability Readiness
+# Runtime Support
 
-This document defines how `gametau` proves readiness for complex game integrations using only public repository artifacts.
+This document describes which runtimes gametau supports, to what level, and how to validate them.
 
-## Scope and Operating Model
+## Stable runtimes
 
-| Dimension | Definition |
-| --- | --- |
-| Validation target | `gametau` runtime, templates, docs, CI/release gates |
-| Evidence source | Public tests, scaffolder seams, and release workflow artifacts |
-| Execution venue | Consumer projects integrating published `gametau` packages |
+Both targets are production-ready and covered by CI, the publish preflight, and consumer smoke tests on every release.
 
-## Pre-Port Gap Closure Baseline
+**Web (WASM)**
+- Commands invoked directly as WASM exports
+- Events via `CustomEvent` DOM bridge
+- Task lifecycle (`startTask`, `pollTask`, `cancelTask`) with non-blocking state tracking
+- Structured diagnostics (`WebtauError` with `code`, `runtime`, `command`, `message`, `hint`)
+- Filesystem, dialog, app, path, and event shims for `@tauri-apps/api` compatibility
 
-The baseline assessment and closure evidence live in this document plus `INTEGRATION-PROXY-VALIDATION.md`.
+**Desktop (Tauri)**
+- Commands invoked via Tauri IPC
+- Events via Tauri event bus, bridged through `createTauriEventAdapter()`
+- Task lifecycle seams in the default scaffold (`src/services/backend.ts`)
+- Full Tauri API passthrough (no shims required)
 
-Current stop-the-port P0 gaps — **all closed** (see Go/No-Go scorecard below):
+## Experimental runtimes
 
-1. ~~No first-class long-running command workflow (`start/poll/cancel` path).~~ **Closed** — `startTask/pollTask/cancelTask` implemented in `packages/webtau/src/task.ts`.
-2. ~~No backend->frontend event stream parity contract for progress/state pushes.~~ **Closed** — Tauri event adapter + parity tests in `packages/webtau/src/adapters/tauri.ts`.
-3. ~~Panic-prone command/state failure paths where structured diagnostics are required.~~ **Closed** — `WebtauError` envelope in `packages/webtau/src/diagnostics.ts`; WASM wrappers return `Result<_, JsError>`.
+**Desktop (Electrobun)** — opt-in only, not the default scaffold target
 
-Adoption kickoff gate:
+Install explicitly to trial:
 
-- All P0 rows in the scorecard must be Green.
-- P0 closure tests must pass for web + desktop.
-- Proxy validation evidence must include CPV-6..CPV-8 scenario artifacts.
+```bash
+npm install webtau@alpha webtau-vite@alpha create-gametau@alpha
+```
 
-## Go/No-Go Scorecard — Adoption Kickoff
+See `examples/electrobun-counter` for a working trial path. Rollout is tracked in [active milestones](https://github.com/devallibus/gametau/milestones).
 
-> **Decision: GO** — All P0 rows are Green. Integration kickoff is authorized.
+## Capability matrix
 
-| Capability | Status | Proof |
-| --- | --- | --- |
-| P0-A: Long-running task lifecycle | **Green** | `packages/webtau/src/task.ts` + `task.test.ts` (20 tests pass) |
-| P0-B: Backend event stream parity | **Green** | `packages/webtau/src/adapters/tauri.ts` + `tauri.test.ts` + `event.test.ts` parity suite |
-| P0-C: Non-panicking diagnostics | **Green** | `packages/webtau/src/diagnostics.ts` (`WebtauError` envelope) + `core.test.ts` envelope shape tests; Rust `cargo test --workspace` passes |
-| Template task seam | **Green** | `packages/create-gametau/templates/base/src/services/backend.ts` exports `startWorldProcessing/pollWorldTask/cancelWorldTask` |
-| Release gate docs canonical | **Green** | `.github/release/RELEASE-GATE-CHECKLIST.md` + `.github/release/RELEASE-INCIDENT-RESPONSE.md` exist; CI `release-gate-contract` job enforces presence |
+| Capability | Web (WASM) | Desktop (Tauri) | Desktop (Electrobun) |
+|---|---|---|---|
+| `invoke()` | Direct WASM export | Tauri IPC | Provider bridge |
+| `listen()` / `emit()` | `CustomEvent` DOM | Tauri event bus | Provider bridge |
+| Task lifecycle | Stable | Stable | Experimental |
+| Structured diagnostics | `WebtauError` envelope | `WebtauError` envelope | `WebtauError` envelope |
+| Filesystem shims | IndexedDB-backed | Native via Tauri | Experimental |
+| Dialog shims | `<dialog>` element | Native via Tauri | Experimental |
+| Window shims | Browser APIs | Native via Tauri | Experimental |
 
-All P0 closure tests (TS + Rust) pass across web and desktop adapter paths.
-CPV-6/7/8 evidence procedures are documented in `INTEGRATION-PROXY-VALIDATION.md`.
+## Known gaps
 
-Current scorecard snapshot:
+- `resolveResource()` in `webtau/path` is not yet implemented for web mode. All other `path` functions are available. Gaps are tracked in the [issue tracker](https://github.com/devallibus/gametau/issues).
 
-| Capability | Status | Source |
-| --- | --- | --- |
-| Long-running command workflow | **Green** | `packages/webtau/src/task.ts` |
-| Backend event stream parity | **Green** | `packages/webtau/src/adapters/tauri.ts` |
-| Non-panicking diagnostics | **Green** | `packages/webtau/src/diagnostics.ts` |
+## Validating integration readiness
 
-## Integration Capability Contract (Minimum)
+To validate that a gametau integration works end-to-end before shipping, use the scenario runbook in [`INTEGRATION-PROXY-VALIDATION.md`](./INTEGRATION-PROXY-VALIDATION.md). It covers eight validation scenarios (scaffold boot, command extension, persistence, diagnostics, task lifecycle, event parity, and more) using only public repository assets.
 
-`gametau` must provide these minimum guarantees to integrators:
-
-1. Deterministic command invocation and typed payload flow in web + desktop.
-2. Clear frontend integration seams through scaffold templates and backend wrappers.
-3. Documented persistence and eventing behavior differences between web and desktop.
-4. Actionable diagnostics for common setup and command contract failures.
-5. Release evidence that proves adoptability, not only package publish success.
-
-Primary contract surfaces:
-
-- `README.md`
-- `INTEGRATION-PROXY-VALIDATION.md`
-- `.github/release/RELEASE-GATE-CHECKLIST.md`
-- `.github/release/RELEASE-INCIDENT-RESPONSE.md`
-
-## Open Proxy Validation Track
-
-Validation must run entirely from public assets:
-
-- Baseline app: `examples/battlestation`
-- Fresh scaffold validation: `create-gametau` generated project
-- Seams under test:
-  - `packages/create-gametau/templates/base/src/index.ts`
-  - `packages/create-gametau/templates/base/src/services/backend.ts`
-  - `packages/create-gametau/templates/base/src-tauri/commands/src/commands.rs`
-
-Use the runbook in `INTEGRATION-PROXY-VALIDATION.md` to execute CPV-1..CPV-8 scenarios and collect evidence.
-
-## DX/Friction Backlog
-
-Backlog is prioritized for integrator success and low adoption friction:
-
-- Adoption blockers (P0): contract clarity, template seam hardening, proxy smoke, diagnostics, release gate linkage.
-- Integration quality (P1): compatibility caveats, migration playbook, persistence/event examples, evidence template consistency.
-- Optimization polish (P2): performance baselines, advanced extension examples, known-limits documentation.
-
-Follow-up items are tracked through the roadmap milestone and tagged GitHub issues.
-
-## Evidence-Based Gates
-
-Readiness requires the following gates:
-
-| Gate | Requirement |
-| --- | --- |
-| G1 Contract clarity | User-facing docs are current and unambiguous |
-| G2 Proxy integration | CPV scenarios pass with reproducible artifacts |
-| G3 Diagnostics quality | Failure scenarios include actionable remediations |
-| G4 Release reliability | Publish and consumer smoke evidence is linked |
-| G5 Handoff readiness | Migration notes, decision log, and known-limits are available |
-
-Release gate enforcement lives in `.github/release/RELEASE-GATE-CHECKLIST.md`.
-
-## Dev -> Master Prerequisite
-
-Execution order remains:
-
-1. Stabilize `development`.
-2. Promote to `master` through release gates.
-3. Continue integration-readiness validation.
-
-`GPUWindow` remains excluded from this critical path while blocker `#106` is open.
-
-## Exit Criteria
-
-- This repo clearly acts as a product-readiness track for public adoption.
-- Integrators can validate required workflows from public artifacts.
-- Evidence gates are satisfied with reproducible artifacts, docs, and smoke outputs.
+Release gate requirements and enforcement are in [`.github/release/RELEASE-GATE-CHECKLIST.md`](.github/release/RELEASE-GATE-CHECKLIST.md).


### PR DESCRIPTION
## Summary
- Full rewrite of README, CONTRIBUTING, CHANGELOG, RUNTIME-PORTABILITY-READINESS, and INTEGRATION-PROXY-VALIDATION
- Separates user-facing content from internal project-management tracking
- No code changes, no version bump

## What changed
- **README**: removed internal noise (docs/ note, gate refs, deploy secrets in Quick Start), merged Quick Start + tutorial into single progressive walkthrough, forward-looking roadmap
- **CONTRIBUTING**: received relocated env/deploy section from README, expanded contribution guidance
- **CHANGELOG**: stripped all Release Evidence / Version Coherence / Release Proof blocks, collapsed alpha entries
- **RUNTIME-PORTABILITY-READINESS**: restructured as "Runtime Support" with capability matrix
- **INTEGRATION-PROXY-VALIDATION**: prose pass, cleaner scenario descriptions

## Test plan
- [ ] Read each file top-to-bottom — no internal notes, CI links, or gate references in README
- [ ] "Environments and deployment" appears in CONTRIBUTING but not README
- [ ] CHANGELOG has no `### Release Evidence` sections
- [ ] RUNTIME-PORTABILITY-READINESS reads as a support-status doc, not a historical closure log
- [ ] Mermaid diagrams render correctly on GitHub

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)