### PR TITLE
chore: promote development into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- `webtau-macros` now generates `#[tauri::command(rename_all = "snake_case")]` for `#[webtau::command]` native wrappers, aligning Tauri IPC argument keys with WASM serde snake_case behavior.
+
 ## [0.5.2] - 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ pub use commands::{init, get_world_view, tick_world};
 
 **Command contract:**
 - First parameter is a reference to your state type: `&T` (read-only) or `&mut T` (mutable). Any name works.
-- Additional parameters become named args on the JS side.
+- Additional parameters become named args on the JS side; pass those keys in snake_case for cross-runtime consistency.
 - Return `T` (serialized), `Result<T, E>` (errors surface to JS), or `()`.
 
 **What the macro generates** (you never write this):

--- a/crates/webtau-macros/src/lib.rs
+++ b/crates/webtau-macros/src/lib.rs
@@ -272,7 +272,7 @@ fn generate_native(def: &CommandDef) -> TokenStream2 {
 
     quote! {
         #[cfg(not(target_arch = "wasm32"))]
-        #[::tauri::command]
+        #[::tauri::command(rename_all = "snake_case")]
         pub fn #pub_name(
             #(#extra_defs,)*
             __webtau_tauri_state: ::tauri::State<'_, ::std::sync::Mutex<#state_ty>>

--- a/crates/webtau-macros/tests/compile-pass/rename_all_snake_case.rs
+++ b/crates/webtau-macros/tests/compile-pass/rename_all_snake_case.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+#[derive(Serialize, Clone)]
+struct RouteSample {
+    count: usize,
+}
+
+struct NavigationState;
+
+mod commands {
+    use super::*;
+
+    #[webtau_macros::command]
+    fn compute_routes(
+        state: &NavigationState,
+        from_body: String,
+        departure_jd: f64,
+        num_samples: usize,
+    ) -> RouteSample {
+        let _ = (state, from_body, departure_jd, num_samples);
+        RouteSample { count: 1 }
+    }
+}
+
+fn main() {}

--- a/crates/webtau-macros/tests/support/tauri-macros/Cargo.toml
+++ b/crates/webtau-macros/tests/support/tauri-macros/Cargo.toml
@@ -6,3 +6,6 @@ publish = false
 
 [lib]
 proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }

--- a/crates/webtau-macros/tests/support/tauri-macros/src/lib.rs
+++ b/crates/webtau-macros/tests/support/tauri-macros/src/lib.rs
@@ -1,7 +1,35 @@
 use proc_macro::TokenStream;
+use syn::{parse_macro_input, punctuated::Punctuated, Expr, ExprLit, Lit, Meta, Token};
 
-/// Test-only no-op replacement for `#[tauri::command]`.
+/// Test-only replacement for `#[tauri::command]` that enforces
+/// `rename_all = "snake_case"` for generated wrappers.
 #[proc_macro_attribute]
-pub fn command(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn command(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr with Punctuated::<Meta, Token![,]>::parse_terminated);
+
+    let has_snake_case_rename = args.iter().any(|meta| {
+        let Meta::NameValue(name_value) = meta else {
+            return false;
+        };
+
+        if !name_value.path.is_ident("rename_all") {
+            return false;
+        }
+
+        matches!(
+            &name_value.value,
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(value),
+                ..
+            }) if value.value() == "snake_case"
+        )
+    });
+
+    if !has_snake_case_rename {
+        return "compile_error!(\"test tauri::command requires `rename_all = \\\"snake_case\\\"`\");"
+            .parse()
+            .expect("valid compile_error tokens");
+    }
+
     item
 }


### PR DESCRIPTION
## Summary
- Promote current development branch into master.
- Includes Tauri IPC key casing alignment to snake_case for #[webtau::command] wrappers.
- Existing desktop callers using camelCase argument keys must migrate to snake_case.

## Test plan
- [x] CI on source PR #123 passed.

Made with [Cursor](https://cursor.com)