### PR TITLE
[codex] Rebaseline Electrobun docs after WGPU release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Runtime provider contracts in `webtau/provider`: `CoreProvider`, `WindowAdapter`, `EventAdapter`, `FsAdapter`, `DialogAdapter`.
 - Provider registry APIs in `webtau/core`: `registerProvider`, `getProvider`, `resetProvider` with lazy Tauri auto-registration.
 - Adapter override hooks in `webtau/window`, `webtau/event`, `webtau/fs`, and `webtau/dialog`.
-- Experimental Electrobun runtime as an opt-in trial path (install with `webtau@alpha`; not the default scaffold target). See `examples/electrobun-counter` and [active milestones](https://github.com/devallibus/gametau/milestones).
+- Initial Electrobun runtime spike as an opt-in alpha path (via `webtau@alpha` at the time, and not yet a scaffold target). That baseline was later expanded by the `v0.7.0` milestone into explicit shell scaffolding, runtime auto-detection, and GPUWindow smoke coverage.
 
 ### Changed
 - `create-gametau` base scaffold now wires `bootstrapTauri()` in desktop mode and ships task lifecycle seams in `src/services/backend.ts`.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Your frontend calls `invoke("command_name")` everywhere. At runtime:
 
 - **Inside Tauri** → routes through Tauri IPC at native speed
 - **In a browser** → calls the WASM export directly
-- **With a registered runtime provider** → routes through the provider (for experimental runtimes)
+- **With a registered runtime provider** → routes through the provider (for provider-backed runtimes such as Electrobun)
 
 The switch is automatic. Zero `if` statements in your game code.
 
@@ -459,7 +459,7 @@ Expands to:
 | `createTauriCoreProvider()` | `CoreProvider` wrapper around `@tauri-apps/api/core` |
 | `createTauriEventAdapter()` | `EventAdapter` wrapper around `@tauri-apps/api/event` |
 
-**`webtau/adapters/electrobun`** — Electrobun desktop bootstrap helpers (experimental).
+**`webtau/adapters/electrobun`** — Electrobun desktop bootstrap helpers for explicit BrowserWindow and GPUWindow shell paths.
 
 | API | Purpose |
 |---|---|
@@ -676,7 +676,7 @@ Expected sizes:
 | Desktop (Tauri) | Stable |
 | Desktop (Electrobun) | Supported via explicit shell selection |
 
-Update: Electrobun now ships with scaffold/runtime auto-detection for `window.__ELECTROBUN__`, an explicit `create-gametau --desktop-shell electrobun` path, and BrowserWindow/GPUWindow counter build lanes. The remaining work is around embedded `<electrobun-wgpu>` showcases, broader GPUWindow renderer abstractions, and release-gate hardening.
+As of March 6, 2026, `gametau` ships scaffold/runtime auto-detection for `window.__ELECTROBUN__`, an explicit `create-gametau --desktop-shell electrobun` path, and BrowserWindow/GPUWindow example lanes. The remaining Electrobun work is now follow-through inside `gametau`: embedded `<electrobun-wgpu>` showcases, broader GPUWindow renderer abstractions, and release-gate hardening.
 
 ### Electrobun support
 
@@ -695,10 +695,12 @@ Electrobun is available as an alternative desktop shell. The current supported s
 - Multi-platform CI dogfood workflow (Ubuntu, macOS, Windows)
 - Public exports from `webtau/adapters/electrobun`
 
-**What's not yet done:**
+**Remaining follow-up work:**
 - BrowserWindow + embedded `<electrobun-wgpu>` showcase
 - Broader GPUWindow example coverage and renderer abstractions beyond the counter proof lane
 - Release-gate promotion and packaging hardening beyond smoke coverage
+
+Earlier upstream-blocked issues [#98](https://github.com/devallibus/gametau/issues/98), [#100](https://github.com/devallibus/gametau/issues/100), [#104](https://github.com/devallibus/gametau/issues/104), and [#106](https://github.com/devallibus/gametau/issues/106) now describe historical baseline work. Remaining milestone tracking is centered on [#159](https://github.com/devallibus/gametau/issues/159) and [#162](https://github.com/devallibus/gametau/issues/162).
 
 See [ELECTROBUN-SHOWCASE.md](./ELECTROBUN-SHOWCASE.md) for the integration walkthrough and [`RUNTIME-PORTABILITY-READINESS.md`](./RUNTIME-PORTABILITY-READINESS.md) for the full capability matrix and known gaps.
 
@@ -706,7 +708,7 @@ See [ELECTROBUN-SHOWCASE.md](./ELECTROBUN-SHOWCASE.md) for the integration walkt
 
 ## Roadmap
 
-**Electrobun (shipped → next steps):**
+**Electrobun (shipped → release follow-up):**
 - ✅ Full adapter surface: window, event, filesystem, dialog
 - ✅ `bootstrapElectrobun()` and provider registry pattern
 - ✅ Auto-detect Electrobun runtime in templates and browser entrypoints


### PR DESCRIPTION
## Summary
This PR rebaselines the public Electrobun narrative after the upstream WGPU release and the milestone work that has already landed in `gametau`.

The immediate user-facing problem was that the repository still described Electrobun support in ways that were true before March 4, 2026 but are now stale. In practice that made the README and changelog lag the actual shipped product surface: scaffold/runtime auto-detection exists, `create-gametau --desktop-shell electrobun` exists, and the repo already contains BrowserWindow and GPUWindow example lanes.

## Root cause
The original Electrobun evaluation language was written while WGPU support was still an upstream dependency and before the milestone work merged. The implementation moved forward through issues like `#160`, `#161`, `#102`, and PR `#167`, but the public docs still used older framing such as "experimental runtime" and "future upstream" style wording.

## Fix
This diff updates the public-facing docs that are actually part of the GitHub repo history:

- `README.md` now describes Electrobun as an explicit supported shell path rather than an abstract experimental provider path.
- The Electrobun support section now distinguishes shipped functionality from remaining release follow-up work.
- The roadmap text now points reviewers at the still-relevant follow-up items instead of upstream blockers that have already been passed.
- `CHANGELOG.md` now records the earlier alpha/Electrobun work as historical context rather than current-state messaging.

I also aligned the local-only decision note in `docs/ELECTROBUN-INTEGRATION-DECISION.md` in my workspace, but `/docs` is ignored in this repository and is therefore not part of the reviewable GitHub diff.

## Validation
This is a docs-only change. Validation for this PR was:

- `git diff --check`
- targeted repo searches to confirm the stale Electrobun wording was removed from the public docs touched here

## Milestone context
Refs `#159`.

After reviewing the current implementation against the issue bodies, `#99` and `#127` also appear satisfied by already-merged work, but I left issue closure out of this PR so the review stays scoped to the doc rebaseline.
