### PR TITLE
[codex] Prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-03-06
+
 ### Added
 - `webtau/adapters/electrobun`: `bootstrapElectrobunFromWindowBridge()`, `createElectrobunWindowBridgeProvider()`, `isElectrobun()`, and `getElectrobunCapabilities()` for first-class Electrobun runtime detection and bridge bootstrap.
 - `webtau`: `getRuntimeInfo()` for runtime id and capability introspection across WASM, Tauri, and provider-backed runtimes.
 - `create-gametau`: `--desktop-shell electrobun` and `--electrobun-mode hybrid|native|dual`.
-- Electrobun counter example BrowserWindow and GPUWindow build lanes.
+- Electrobun counter example BrowserWindow and GPUWindow build lanes, including the hybrid embedded WGPU showcase path.
+- Battlestation example BrowserWindow and GPUWindow runtime lanes with a native Three WebGPU proof path.
 
 ### Changed
 - Scaffolded entrypoints now auto-check for `window.__ELECTROBUN__` before falling back to Tauri or plain WASM.
 - Electrobun counter example and generated Electrobun shell files now target the WGPU-capable `electrobun@^1.15.1` line.
+- CI and release-gate docs now treat `Electrobun Hybrid + GPU Smoke` as a required release lane.
 
 ## [0.6.0] - 2026-03-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.77"
 license = "Apache-2.0"

--- a/crates/webtau/Cargo.toml
+++ b/crates/webtau/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-webtau-macros = { path = "../webtau-macros", version = "=0.6.0" }
+webtau-macros = { path = "../webtau-macros", version = "=0.7.0" }

--- a/packages/create-gametau/package.json
+++ b/packages/create-gametau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-gametau",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Scaffold a Tauri game that deploys to web + desktop",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-gametau/templates/base/package.json
+++ b/packages/create-gametau/templates/base/package.json
@@ -11,12 +11,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "webtau": "^0.6.0"
+    "webtau": "^0.7.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.6.0",
+    "webtau-vite": "^0.7.0",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml
+++ b/packages/create-gametau/templates/base/src-tauri/commands/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 {{PROJECT_NAME}}-core = { path = "../core" }
-webtau = "0.6.0"
+webtau = "0.7.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tauri = { version = "2", features = [] }

--- a/packages/create-gametau/templates/base/src-tauri/wasm/Cargo.toml
+++ b/packages/create-gametau/templates/base/src-tauri/wasm/Cargo.toml
@@ -11,7 +11,7 @@ wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.2", features = ["js"] }
-webtau = "0.6.0"
+webtau = "0.7.0"
 {{PROJECT_NAME}}-core = { path = "../core" }
 {{PROJECT_NAME}}-commands = { path = "../commands" }
 

--- a/packages/create-gametau/templates/pixi/package.json
+++ b/packages/create-gametau/templates/pixi/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "pixi.js": "^8.0.0",
-    "webtau": "^0.6.0"
+    "webtau": "^0.7.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.6.0",
+    "webtau-vite": "^0.7.0",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/create-gametau/templates/three/package.json
+++ b/packages/create-gametau/templates/three/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "three": "^0.172.0",
-    "webtau": "^0.6.0"
+    "webtau": "^0.7.0"
   },
   "devDependencies": {
     "@types/three": "^0.172.0",
     "typescript": "^5.8.0",
     "vite": "^6.0.0",
-    "webtau-vite": "^0.6.0",
+    "webtau-vite": "^0.7.0",
     "@tauri-apps/cli": "^2.0.0",
     "@tauri-apps/api": "^2.0.0"
   }

--- a/packages/webtau-vite/package.json
+++ b/packages/webtau-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtau-vite",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Vite plugin for webtau — wasm-pack automation + Tauri API aliasing",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/webtau/package.json
+++ b/packages/webtau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtau",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Deploy Tauri games to web + desktop from one codebase",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
This PR is the dedicated `v0.7.0` release-prep step after the Electrobun milestone feature work landed and the follow-up doc rebaseline merged in `#168`.

The user-facing goal here is not new functionality. It is to make the repository publishable and reviewable as the `0.7.0` release line by aligning the package/crate/template version surfaces and by turning the current `Unreleased` notes into a concrete `0.7.0` changelog entry.

## Root cause
After the Electrobun workstream merged, the repo still had a split state:

- shipped code and docs already reflected the new `v0.7.0` surface
- publishable package/crate manifests still reported `0.6.0`
- scaffold templates still depended on the `0.6.0` package line
- the changelog content existed only under `Unreleased`, which is not the right state for a release-prep PR

Without this prep step, the next tag would not line up with the published manifest versions or the generated-template dependency expectations.

## Fix
This PR:

- bumps the workspace Rust version line from `0.6.0` to `0.7.0`
- updates the internal `webtau` -> `webtau-macros` dependency pin to `=0.7.0`
- bumps the three publishable npm packages to `0.7.0`
- updates scaffold template dependencies so generated projects reference `webtau` / `webtau-vite` `^0.7.0`
- promotes the current `Unreleased` Electrobun entry into a dated `0.7.0` changelog section
- expands that changelog entry to mention the Battlestation runtime lanes and the Electrobun smoke/release-gate lane, so the release notes match what shipped between `v0.6.0` and today

## Validation
I validated this PR with:

- `cargo check`
- `bun run test`
- `git diff --check`

Note: an initial `bun run vitest run` attempt failed because this repo does not expose a root `vitest` script; I then reran the correct repo-level test entrypoint with `bun run test`, which passed.

## Milestone context
Refs `#162`.

At this point milestone `11` is down to the umbrella tracker only. This PR is the release-prep step that follows the completed feature/docs work.
